### PR TITLE
feat: add ibis

### DIFF
--- a/mplang/backend/sql_duckdb.py
+++ b/mplang/backend/sql_duckdb.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from mplang.core.pfunc import PFunction, TableHandler
+from mplang.core.table import TableLike
+
+
+class DuckDBHandler(TableHandler):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def setup(self) -> None: ...
+    def teardown(self) -> None: ...
+    def list_fn_names(self) -> list[str]:
+        return ["sql[duckdb]"]
+
+    def execute(self, pfunc: PFunction, args: list[TableLike]) -> list[TableLike]:
+        if pfunc.fn_type == "sql[duckdb]":
+            return self.do_run(pfunc, args)
+        else:
+            raise ValueError(f"unsupported fn_type, {pfunc.fn_type}")
+
+    def do_run(
+        self,
+        pfunc: PFunction,
+        args: list[TableLike],
+    ) -> list[TableLike]:
+        import duckdb
+        import pandas as pd
+
+        assert "in_names" in pfunc.attrs, (
+            f"cannot find in_names in attrs{list(pfunc.attrs.keys())}."
+        )
+        in_names: list[str] = json.loads(pfunc.attrs["in_names"])
+
+        conn = duckdb.connect(":memory:")
+
+        # register input tables
+        for arg, name in zip(args, in_names, strict=True):
+            # assert isinstance(arg, pd.DataFrame)
+            if isinstance(arg, pd.DataFrame):
+                df = arg
+            elif isinstance(arg, list):
+                # const df, only for test
+                df = pd.DataFrame.from_records(arg)
+            else:
+                raise ValueError(f"unsupport type, {type(arg)}")
+            conn.register(name, df)
+
+        res_df = conn.execute(pfunc.fn_text).fetchdf()
+        return [res_df]

--- a/mplang/frontend/ibis_cc.py
+++ b/mplang/frontend/ibis_cc.py
@@ -81,7 +81,7 @@ def ibis_compile(
 
     normalized_fn, in_vars = normalize_fn(func, args, kwargs, is_variable)
 
-    in_args, in_schemas, in_names = [], [], [], []
+    in_args, in_schemas, in_names = [], [], []
     idx = 0
     for arg in in_vars:
         columns = [(p[0], p[1].to_numpy()) for p in arg.schema.columns]

--- a/mplang/frontend/ibis_cc.py
+++ b/mplang/frontend/ibis_cc.py
@@ -93,7 +93,7 @@ def ibis_compile(
         in_names.append(name)
         idx += 1
 
-    result = normalized_fn(*in_args)
+    result = normalized_fn(in_args)
     assert isinstance(result, ibis.Table)
     pfunc = ibis2sql(result, in_schemas, in_names, func.__name__)
     _, treedef = jax.tree.flatten(result)

--- a/mplang/frontend/ibis_cc.py
+++ b/mplang/frontend/ibis_cc.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import inspect
+import json
+from collections.abc import Callable
+from typing import Any
+
+import ibis
+import jax
+
+from mplang.core import dtype
+from mplang.core.mpobject import MPObject
+from mplang.core.pfunc import PFunction
+from mplang.core.table import TableType
+from mplang.utils.func_utils import normalize_args
+
+
+def ibis2sql(
+    expr: ibis.Table,
+    in_schemas: list[ibis.Schema],
+    in_names: list[str],
+    fn_name: str = "",
+) -> PFunction:
+    """
+    Compile a ibis expr to sql and return the PFunction.
+
+    Args:
+        expr: ibis expr.
+        in_schemas: the input table schemas
+        in_names: the input table names, If there is only one table, it is usually defaulted to "table"
+    Return:
+        PFunction: The compiled PFunction
+    """
+    assert len(in_schemas) == len(in_names), (
+        f"length of input table names and schemas mismatch. {len(in_schemas)}!={len(in_names)}"
+    )
+
+    def _convert(s: ibis.Schema) -> TableType:
+        return TableType.from_pairs([
+            (name, dtype.from_numpy(dt.to_numpy())) for name, dt in s.fields.items()
+        ])
+
+    ins_info = [_convert(s) for s in in_schemas]
+    outs_info = [_convert(expr.schema())]
+
+    sql = ibis.to_sql(expr, dialect="duckdb")
+    pfn = PFunction(
+        fn_type="sql[duckdb]",
+        fn_name=fn_name,
+        fn_text=sql,
+        ins_info=tuple(ins_info),
+        outs_info=tuple(outs_info),
+        in_names=json.dumps(in_names),
+    )
+    return pfn
+
+
+def ibis_compile(
+    func: Callable, *args: Any, **kwargs: Any
+) -> tuple[PFunction, list[MPObject], Any]:
+    """
+    IBIS compilation helper function.
+    The func signature must like def foo(t0:ibis.Table, t1:ibis.Table)->ibis.Table
+    """
+
+    normal_args = normalize_args(func, args, kwargs)
+    in_args, in_schemas, in_names, in_vars = [], [], [], []
+    idx = 0
+    for arg in normal_args:
+        if not isinstance(arg, MPObject):
+            in_args.append(arg)
+            continue
+        assert arg.schema
+        columns = [(p[0], p[1].to_numpy()) for p in arg.schema.columns]
+        schema = ibis.schema(columns)
+        name = f"table{idx}"
+        table = ibis.table(schema=schema, name=name)
+        in_args.append(table)
+        in_schemas.append(schema)
+        in_names.append(name)
+        in_vars.append(arg)
+        idx += 1
+
+    result = func(*in_args)
+    assert isinstance(result, ibis.Table)
+    pfunc = ibis2sql(result, in_schemas, in_names, func.__name__)
+    _, treedef = jax.tree.flatten(result)
+    return pfunc, in_vars, treedef
+
+
+def is_ibis_function(func: Callable) -> bool:
+    """
+    Verify whether a function is an ibis function.
+    The func signature should like def foo(t0:ibis.Table, t1:ibis.Table)->ibis.Table
+    """
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError):
+        return False
+
+    ret_anno = sig.return_annotation
+    if ret_anno is ibis.Table:
+        return True
+
+    for param in sig.parameters.values():
+        par_anno = param.annotation
+        if par_anno is ibis.Table:
+            return True
+
+    return False

--- a/mplang/runtime/executor/server.py
+++ b/mplang/runtime/executor/server.py
@@ -36,6 +36,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 from mplang.backend.builtin import BuiltinHandler
 from mplang.backend.spu import SpuHandler
+from mplang.backend.sql_duckdb import DuckDBHandler
 from mplang.backend.stablehlo import StablehloHandler
 from mplang.core.mask import Mask
 from mplang.core.mpir import Reader
@@ -257,6 +258,7 @@ class Execution:
                 BuiltinHandler(),
                 StablehloHandler(),
                 spu_handler,
+                DuckDBHandler(),
             ],
         )
 

--- a/mplang/runtime/simulation.py
+++ b/mplang/runtime/simulation.py
@@ -25,6 +25,7 @@ import spu.libspu as libspu
 
 from mplang.backend.builtin import BuiltinHandler
 from mplang.backend.spu import SpuHandler
+from mplang.backend.sql_duckdb import DuckDBHandler
 from mplang.backend.stablehlo import StablehloHandler
 from mplang.core.interp import InterpContext, InterpVar
 from mplang.core.mask import Mask
@@ -120,6 +121,7 @@ class Simulator(InterpContext):
                     BuiltinHandler(),
                     StablehloHandler(),
                     spu_handlers[rank],
+                    DuckDBHandler(),
                 ],
             )
             for rank in range(self.psize())

--- a/mplang/utils/func_utils.py
+++ b/mplang/utils/func_utils.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -100,33 +99,6 @@ def var_demorph(variables: list, immediates: list, morph_info: MorphStruct) -> A
     values_tree, split_info = morph_info
     values_flat = list_reconstruct(variables, immediates, list(split_info))
     return tree_unflatten(values_tree, values_flat)
-
-
-def normalize_args(fn: Callable, args: Any, kwargs: Any) -> list:
-    """convert *args and **kwargs to list of args"""
-
-    signature = inspect.signature(fn)
-    parameters = list(signature.parameters.keys())
-    final_args = list(args)
-
-    for param in parameters[len(args) :]:
-        if param in kwargs:
-            final_args.append(kwargs[param])
-            del kwargs[param]
-        elif (
-            param in signature.parameters
-            and signature.parameters[param].default is not inspect.Parameter.empty
-        ):
-            final_args.append(signature.parameters[param].default)
-        else:
-            raise TypeError(
-                f"Missing required argument: {fn.__name__},{param}, {args}, {kwargs}"
-            )
-
-    if kwargs:
-        raise TypeError(f"Unexpected keyword arguments: {kwargs}")
-
-    return final_args
 
 
 def normalize_fn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,16 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "spu==0.9.4.dev20250618",  # TODO(jint): use a more flexible version constraint like "spu >= 0.9.4"
+    "spu==0.9.4.dev20250618", # TODO(jint): use a more flexible version constraint like "spu >= 0.9.4"
     "grpcio==1.56.2",
     "grpcio-tools==1.56.2",
     "protobuf>=4.21.6,<5.0",
+    "ibis-framework==10.8.0",
+    "sqlglot==27.7.0",        # for ibis parse_sql
+    # runtime only
     "google-api-core==2.24.2", # TODO(jint): this is only required for runtime.
     "pandas>=2.0.0",
+    "duckdb>=1.0.0",
 ]
 
 [dependency-groups]
@@ -40,6 +44,9 @@ dev = [
     "sphinx>=7.0.0",
     "sphinx_rtd_theme>=1.2.0",
     "mypy-protobuf==3.6.0",
+    # for ibis test
+    "pyarrow==21.0.0",
+    "pyarrow_hotfix==0.7",
 ]
 examples = [
     "numpy==1.26.4",

--- a/tests/backend/test_sql_duckdb.py
+++ b/tests/backend/test_sql_duckdb.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ibis
+import numpy.testing as npt
+import pandas as pd
+import pytest
+
+import mplang
+from mplang import simp
+from mplang.backend.sql_duckdb import DuckDBHandler
+from mplang.frontend import ibis_cc
+
+
+class TestDuckDBHandler:
+    def test_duckdb_run(self):
+        # ibis_fe
+        tbl_name = "table"
+        schema = {"a": "int", "b": "int", "c": "float"}
+        in_tbl = ibis.table(schema=schema, name=tbl_name)
+        result_expr = in_tbl["a"] + in_tbl["b"]
+        new_table = in_tbl.mutate(d=result_expr)
+        pfn = ibis_cc.ibis2sql(new_table, [in_tbl.schema()], [tbl_name])
+
+        # duckdb run
+        dh = DuckDBHandler()
+
+        in_tbl = pd.DataFrame({
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": [7.1, 8.1, 9.1],
+        })
+        ep_tbl = pd.DataFrame({
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": [7.1, 8.1, 9.1],
+            "d": [5, 7, 9],
+        })
+        ot_tbls = dh.execute(pfn, [in_tbl])
+        assert len(ot_tbls) == 1
+        ot_tbl = ot_tbls[0]
+
+        npt.assert_allclose(ot_tbl, ep_tbl, rtol=1e-7, atol=1e-8)
+
+    @pytest.mark.parametrize("op", ["+", "-", "*", "/"])
+    @pytest.mark.parametrize(
+        "features,new_feature_name",
+        [
+            (["a", "b"], "r"),
+            (["a", "b"], "a"),
+        ],
+    )
+    def test_binary_op(self, op: str, features, new_feature_name):
+        def _binary_op(t: ibis.Table, op: str) -> ibis.Table:
+            match op:
+                case "+":
+                    result_expr = t[features[0]] + t[features[1]]
+                case "-":
+                    result_expr = t[features[0]] - t[features[1]]
+                case "*":
+                    result_expr = t[features[0]] * t[features[1]]
+                case "/":
+                    result_expr = t[features[0]] / t[features[1]]
+                case _:
+                    raise ValueError(f"Unsupported operation: {op}")
+
+            res_t = t.mutate(**{new_feature_name: result_expr})
+            return res_t
+
+        def example():
+            data = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [4.1, 5.1, 6.1]})
+            in_tbl = simp.constant(data)
+            out_tbl = simp.runAt(0, _binary_op)(in_tbl, op)
+
+            return out_tbl
+
+        sim2 = mplang.Simulator(2)
+        res = mplang.evaluate(sim2, example)
+        print(f"output table: {op}, {new_feature_name}\n", mplang.fetch(sim2, res))
+
+    def test_union(self):
+        """
+        Multiple inputs single output
+        """
+
+        def _union(t1: ibis.Table, t2: ibis.Table) -> ibis.Table:
+            return t1.union(t2, distinct=False)
+
+        def example():
+            import pandas as pd
+
+            df1 = pd.DataFrame({"f0": [0.1, 0.2], "f1": [1, 2]})
+            df2 = pd.DataFrame({"f0": [0.3, 0.4], "f1": [3, 4]})
+            t1 = simp.constant(df1)
+            t2 = simp.constant(df2)
+            res = simp.runAt(0, _union)(t1, t2)
+            return res
+
+        sim2 = mplang.Simulator(2)
+        res = mplang.evaluate(sim2, example)
+        out_tbl = mplang.fetch(sim2, res)
+        print(f"output table: \n {out_tbl[0]}")

--- a/tests/frontend/test_ibis.py
+++ b/tests/frontend/test_ibis.py
@@ -1,0 +1,894 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import ibis
+import numpy.testing as npt
+import pandas as pd
+import pytest
+
+# you can switch engine in ["duckdb", "substrait"]
+# some testing may crash in "substrait"
+_ibis_engine = "duckdb"
+
+
+class TestIbis:
+    def test_scalar_udf(self):
+        def uppercase_string(s: str) -> str:
+            return s.upper()
+
+        ibis_uppercase_string = ibis.udf.scalar.builtin(name="uppercase_string")(
+            uppercase_string
+        )
+
+        t = ibis.table(schema={"col": "str"}, name="table")
+        expr = t.select(upper_str=ibis_uppercase_string(t["col"]))
+
+        data = {"col": ["hello", "world"]}
+        res = self._eval_duckdb(expr, [data], udfs=[uppercase_string])
+        print(res)
+
+    @pytest.mark.parametrize(
+        "train_size,test_size,shuffle,random_state",
+        [
+            (0.75, None, False, None),
+            (10, None, False, None),
+            # (None, 0.35, True, None),
+            # (None, 30, True, None),
+        ],
+    )
+    def test_train_test_split(self, train_size, test_size, shuffle, random_state):
+        if random_state is None:
+            random_state = 1024
+        if train_size is None and test_size is None:
+            raise ValueError("train_size and test_size cannot all be None")
+
+        data = {
+            "id": [f"id{i}" for i in range(100)],
+            "a1": [f"a{i}" for i in range(100)],
+            "a2": list(range(100)),
+        }
+
+        schema = {"id": "str", "a1": "str", "a2": "int"}
+        t = self._memtable(data, schema=schema)
+        total = t.count().execute()
+
+        if train_size is not None and train_size <= 1.0:
+            train_size = int(total * train_size)
+        if test_size is not None and test_size <= 0:
+            test_size = int(total * test_size)
+        if train_size is None:
+            train_size = total - test_size
+        if test_size is None:
+            test_size = total - train_size
+        if train_size + test_size > total:
+            raise ValueError(f"split size overflow: {train_size}, {test_size}, {total}")
+
+        # shuffle will crash.
+        # duckdb.duckdb.InvalidInputException: Invalid Input Error:
+        # More than one row returned by a subquery used as an expression - scalar subqueries can only return a single row.
+        # if shuffle:
+        #     # TODO: random_state
+        #     t = t.order_by(ibis.random())
+
+        train_data = t.limit(train_size).execute()
+        test_data = t.limit(test_size, offset=train_size).execute()
+        train_data = train_data.reset_index(drop=True)
+        test_data = test_data.reset_index(drop=True)
+        print(
+            f"totol_size: {total}, train_size:{train_size}, test_size:{test_size}, shuffle: {shuffle}"
+        )
+        print(f"train_data: {train_data.shape} \n {train_data.head(5)}")
+        print(f"test_data:  {test_data.shape}  \n {test_data.head(5)}")
+
+    def test_join(self):
+        schema1 = {"id1": "str", "id2": "str", "a1": "int", "a2": "bool"}
+        schema2 = {"id3": "str", "id4": "str", "b1": "float"}
+
+        keys1 = ["id1", "id2"]
+        keys2 = ["id3", "id4"]
+
+        def _join(t0: ibis.Table, t1: ibis.Table) -> ibis.Table:
+            cond = ibis.and_(*[
+                getattr(t0, k1) == getattr(t1, k2)
+                for k1, k2 in zip(keys1, keys2, strict=True)
+            ])
+            return t0.join(t1, cond, how="inner")
+
+        t0 = ibis.table(schema=schema1, name="table0")
+        t1 = ibis.table(schema=schema2, name="table1")
+        aligned = _join(t0, t1)
+        data1 = {
+            "id1": ["k1", "k2"],
+            "id2": ["k3", "k4"],
+            "a1": [1, 2],
+            "a2": [True, False],
+        }
+        data2 = {
+            "id3": ["k1", "k2", "ka"],
+            "id4": ["k3", "k5", "kb"],
+            "b1": [1.1, 2.1, 3.1],
+        }
+        res = self._eval(aligned, data1, data2, table_names=["table0", "table1"])
+        print(f"join res: \n {res}")
+
+    def test_union(self):
+        schema = {"id": "str", "f0": "str", "f1": "int"}
+        t1 = ibis.table(schema=schema, name="table1")
+        t2 = ibis.table(schema=schema, name="table2")
+        expr = t1.union(t2, distinct=False)
+        data1 = {"id": ["ID1", "ID2"], "f0": ["x1", "x2"], "f1": [1, 2]}
+        data2 = {"id": ["ID3", "ID4"], "f0": ["x3", "x4"], "f1": [3, 4]}
+        df1 = pd.DataFrame(data1)
+        df2 = pd.DataFrame(data2)
+
+        res = self._eval(expr, data1, data2, table_names=["table1", "table2"])
+        print(f"union res: \n{res}")
+        combined_df = pd.concat([df1, df2], ignore_index=True)
+        npt.assert_equal(res, combined_df.to_numpy())
+
+    @pytest.mark.parametrize("op", ["+", "-", "*", "/"])
+    @pytest.mark.parametrize(
+        "features,new_feature_name",
+        [
+            (["a", "b"], "r"),
+            (["a", "b"], "a"),
+            (["a", "a"], "r"),
+            (["a", "a"], "a"),
+            (["a", "c"], "r"),
+        ],
+    )
+    def test_binary_op(self, op: str, features, new_feature_name):
+        t = ibis.table(schema={"a": "int", "b": "int", "c": "float"}, name="table")
+
+        match op:
+            case "+":
+                result_expr = t[features[0]] + t[features[1]]
+            case "-":
+                result_expr = t[features[0]] - t[features[1]]
+            case "*":
+                result_expr = t[features[0]] * t[features[1]]
+            case "/":
+                result_expr = t[features[0]] / t[features[1]]
+            case _:
+                raise ValueError(f"Unsupported operation: {op}")
+
+        new_table = t.mutate(**{new_feature_name: result_expr})
+
+        assert new_feature_name in new_table.schema()
+        res = self._eval(
+            new_table, {"a": [1, 2, 3], "b": [4, 5, 6], "c": [4.0, 5.0, 6.0]}
+        )
+        print(f"{new_feature_name} = {features[0]} {op} {features[1]}:\n {res}")
+
+    @pytest.mark.parametrize("columns", [["a", "b", "c", "d"]])
+    @pytest.mark.parametrize("astype", ["int", "float", "string"])
+    def test_cast(self, columns: list[str], astype: str):
+        t = ibis.table(
+            schema={"a": "int", "b": "float", "c": "string", "d": "bool"}, name="table"
+        )
+        # exprs = {col: t[col].cast(astype) for col in columns}
+        exprs = {}
+        for name in columns:
+            col = t[name]
+            # substrait donot support strip/trim and try_cast
+            if col.type().is_string():
+                col = col.strip()
+            exprs[name] = col.cast(astype)
+        new_t = t.mutate(**exprs)
+        input = {
+            "a": [1, 2, 3],
+            "b": [4.1, 5.1, 6.1],
+            "c": ["7", "8", "9"],  # "8.1" -> 8 will panic
+            "d": [True, False, True],
+        }
+        res = self._eval(new_t, input)
+        print(f"columns:{columns} cast to {astype}\n {res}")
+
+    @pytest.mark.parametrize(
+        "features,op,operands",
+        [
+            (["a1", "a2", "b1"], "standardize", []),
+            (["a1", "a2", "b1"], "normalize", []),
+            (["a1", "b1"], "range_limit", ["1", "2"]),
+            (["a1", "b1"], "unary", ["+", "+", "1"]),  # unary_+
+            (["a1", "b1"], "unary", ["+", "-", "1"]),  # unary_-
+            (["a1", "b1"], "unary", ["-", "-", "1"]),  # unary_reverse_-
+            (["a1", "b1"], "unary", ["+", "*", "2"]),  # unary_*
+            (["a1", "b1"], "unary", ["+", "/", "3"]),  # unary_/
+            (["a1", "b1"], "reciprocal", []),
+            (["a1", "b1"], "round", []),
+            (["a1", "b1"], "log_round", ["10"]),
+            (["a1", "b1"], "log", ["e", "10"]),
+            (["a1", "b1"], "log", ["2", "10"]),
+            (["b1"], "sqrt", []),
+            (["a1", "b1"], "exp", []),
+            (["a3"], "length", []),
+            (["a3"], "substr", ["0", "2"]),
+        ],
+    )
+    def test_feature_calculate(self, features: list[str], op: str, operands: list[str]):
+        t: ibis.Table = ibis.table(
+            schema={"a1": "float", "a2": "float", "a3": "string", "b1": "int"},
+            name="table",
+        )
+
+        def _standardize(col: ibis.Column):
+            mean_expr = col.mean()
+            std_expr = col.std()
+            return ibis.cases((std_expr == 0, 0), else_=(col - mean_expr) / std_expr)
+
+        def _normalize(col: ibis.Column):
+            # norm = (x-min)/(ma-min)
+            min_expr = col.min()
+            max_expr = col.max()
+
+            denominator = max_expr - min_expr
+
+            return ibis.cases(
+                (denominator == 0, 0), else_=(col - min_expr) / denominator
+            )
+
+        def _range_limit(col: ibis.Column):
+            op_cnt = len(operands)
+            if op_cnt != 2:
+                raise ValueError(
+                    f"range limit operator need 2 operands, but got {op_cnt}"
+                )
+            op0 = float(operands[0])
+            op1 = float(operands[1])
+            if op0 > op1:
+                raise ValueError(
+                    f"range limit operator expect min <= max, but get [{op0}, {op1}]"
+                )
+            new_col = ibis.cases((col < op0, op0), (col > op1, op1), else_=col)
+            return new_col
+
+        def _unary(col: ibis.Column):
+            op_cnt = len(operands)
+            if op_cnt != 3:
+                raise ValueError(f"unary operator needs 3 operands, but got {op_cnt}")
+            op0 = operands[0]
+            if op0 not in ["+", "-"]:
+                raise ValueError(f"unary op0 should be [+ -], but get {op0}")
+            op1 = operands[1]
+            if op1 not in ["+", "-", "*", "/"]:
+                raise ValueError(f"unary op1 should be [+ - * /], but get {op1}")
+            op3 = float(operands[2])
+            if op1 == "+":
+                new_col = col + op3
+            elif op1 == "-":
+                new_col = col - op3 if op0 == "+" else op3 - col
+            elif op1 == "*":
+                new_col = col * op3
+            elif op1 == "/":
+                if op0 == "+":
+                    if op3 == 0:
+                        raise ValueError("unary operator divide zero")
+                    new_col = col / op3
+                else:
+                    new_col = op3 / col
+            return new_col
+
+        def _reciprocal(col: ibis.Column):
+            return 1 / col
+
+        def _round(col: ibis.Column):
+            return col.round()
+
+        def _log_round(col: ibis.Column):
+            op_cnt = len(operands)
+            if op_cnt != 1:
+                raise ValueError(f"log operator needs 1 operands, but got {op_cnt}")
+            op0 = float(operands[0])
+            return (col + op0).log(2).round(2)
+
+        def _log(col: ibis.Column):
+            import math
+
+            op_cnt = len(operands)
+            if op_cnt != 2:
+                raise ValueError(f"log operator needs 2 operands, but got {op_cnt}")
+
+            op0 = operands[0]
+            op1 = float(operands[1])
+            adjusted_col = col + op1
+
+            if op0 == "e":
+                # 自然对数:log_e(x) = ln(x)
+                new_col = adjusted_col.log(math.e)
+            else:
+                # 任意底数对数:log_base(x)
+                base = float(op0)
+                new_col = adjusted_col.log(base)
+
+            return new_col
+
+        def _sqrt(col: ibis.Column):
+            return col.sqrt()
+
+        def _exp(col: ibis.Column):
+            return col.exp()
+
+        def _length(col: ibis.Column):
+            return col.length()
+
+        def _substr(col: ibis.Column):
+            op_cnt = len(operands)
+            if op_cnt != 2:
+                raise ValueError(f"substr operator needs 2 operands, but got {op_cnt}")
+            start = int(operands[0])
+            length = int(operands[1])
+            return col.substr(start + 1, length)
+
+        fn_map = {
+            "standardize": _standardize,
+            "normalize": _normalize,
+            "range_limit": _range_limit,
+            "unary": _unary,
+            "reciprocal": _reciprocal,
+            "round": _round,
+            "log_round": _log_round,
+            "log": _log,
+            "sqrt": _sqrt,
+            "exp": _exp,
+            "length": _length,
+            "substr": _substr,
+        }
+        fn = fn_map[op]
+        exprs = {name: fn(t[name]) for name in features}
+        new_t = t.mutate(**exprs)
+
+        input = {
+            "a1": [i * (-0.8) for i in range(3)],
+            "a2": [0.1] * 3,
+            "a3": ["AAA", "BBB", "CCC"],
+            "b1": list(range(3)),
+        }
+        res = self._eval(new_t, input)
+        print(f"calulate {op},{operands}\n {res}")
+
+    def test_fillna(self):
+        pass
+
+    @pytest.mark.parametrize(
+        "drop_type,min_freq,features",
+        [
+            ("first", 0.1, ["a1", "a2", "a3"]),
+            ("mode", 0.1, ["a1", "a2", "a3"]),
+        ],
+    )
+    def test_onehot(self, drop_type: str, min_freq: float, features: list):
+        # onehot 需要生成相对负责的rule,无法一次性生成expr
+        data = {
+            "id": [str(i) for i in range(17)],
+            "a1": ["K"] + ["F"] * 13 + ["", "M", "N"],
+            "a2": [0.1, 0.2, 0.3] * 5 + [0.4] * 2,
+            "a3": [1] * 17,
+            "y": [0] * 17,
+        }
+        schema = {"id": "str", "a1": "str", "a2": "float", "a3": "int", "y": "int"}
+        t = self._memtable(data, schema=schema)
+        row_count = t.count().execute()
+        print(f"row_count: {type(row_count)} {row_count}")
+        min_freq_count = round(row_count * min_freq)
+
+        def _fit_col(col_name: str):
+            col = t[col_name]
+            dist_count = col.nunique().execute()
+
+            if dist_count >= 100:
+                raise ValueError(
+                    f"the feature has too many categories: {col_name}, {dist_count}"
+                )
+
+            if drop_type == "mode":
+                expr = (
+                    t.group_by(col_name)
+                    .aggregate(count=col.count())
+                    .order_by(ibis.desc("count"))
+                    .limit(1)
+                )
+                res = expr.execute()
+                drop_category = res[col_name].iloc[0]
+            elif drop_type == "first":
+                res = t.limit(1).execute()
+                drop_category = res[col_name].iloc[0]
+            elif drop_type == "no_drop":
+                drop_category = None
+            else:
+                raise ValueError(f"unsupported drop type: {drop_type}")
+
+            if drop_category is None:
+                filtered = t.filter(col.isnull().not_())
+            else:
+                filtered = t.filter(col != drop_category)
+            # 聚合出每个元素个数
+            freq_table: pd.DataFrame = (
+                filtered.group_by(col_name).aggregate(freq=col.count()).execute()
+            )
+            # category
+            category = []
+            infrequent = []
+            for _, row in freq_table.iterrows():
+                name = row[col_name]
+                freq = row["freq"]
+                if freq < min_freq_count:
+                    infrequent.append(name)
+                else:
+                    category.append([name])
+
+            if infrequent:
+                category.append(infrequent)
+
+            return category, drop_category
+
+        onehot_rules = {}
+        drop_rules = {}
+        for col_name in features:
+            category, drop_category = _fit_col(col_name)
+            onehot_rules[col_name] = category
+            if drop_category:
+                drop_rules[col_name] = drop_category
+
+        # onehot_rules: {'a1': [['F'], ['', 'N', 'M']], 'a2': [[0.3], [0.4], [0.2]], 'a3': []}, drop_rules: {'a1': 'K', 'a2': 0.1, 'a3': 1}
+        print(f"onehot_rules: {onehot_rules}, drop_rules: {drop_rules}")
+        # apply rule
+        exprs = {}
+        for col_name, col_rules in onehot_rules.items():
+            col = t[col_name]
+            for idx, values in enumerate(col_rules):
+                new_col = ibis.ifelse(col.isin(values), 1.0, 0.0)
+                exprs[f"{col_name}_{idx}"] = new_col
+        old_columns = [col for col in t.columns if col not in onehot_rules]
+        new_t = t.mutate(**exprs).select(old_columns + list(exprs.keys()))
+        res = new_t.execute()
+        print(f"onehot res: \n {res}")
+
+    @pytest.mark.parametrize(
+        "bin_method,bin_num,features",
+        [
+            ("eq_range", 3, ["a1", "a2"]),
+            ("quantile", 3, ["a1", "a2"]),
+            ("", 0, ["s"]),
+        ],
+    )
+    def test_binning(self, bin_method: str, bin_num: int, features: list):
+        # 需要对不同列,不同的类型,不同的分箱方法生成不同的规则,也没有办法使用一个表达式完成
+        schema = ibis.schema({"a1": "int", "a2": "float", "s": "str"})
+        data = {
+            "a1": [1, 2, 3, 4, 5],
+            "a2": [1.1, 2.2, 3.3, 4.4, 5.5],
+            "s": ["s1", "s2", "s2", "s4", "s5"],
+        }
+
+        t = self._memtable(data, schema=schema)
+
+        def _fit_feature_bins(col_name: str) -> dict:
+            col = t[col_name]
+            col_dtype = t.schema().fields[col_name]
+            if col_dtype.is_string():
+                categories_df = t.drop_null(col_name).distinct(on=col_name).execute()
+                categories = categories_df[col_name]
+                split_points = sorted(categories)
+                return {"type": "str", "split_points": split_points}
+            else:
+                if bin_method == "quantile":
+                    # bins, split_points = pd.qcut(
+                    #    f_data, bin_num, labels=False, duplicates='drop', retbins=True
+                    # )
+                    quantiles = [i / bin_num for i in range(1, bin_num)]
+                    split_points_ibis = col.approx_quantile(quantiles)
+                    split_points = split_points_ibis.execute()
+                    split_points = sorted(set(split_points))
+                elif bin_method == "eq_range":
+                    # bins, split_points = pd.cut(
+                    #     f_data, bin_num, labels=False, duplicates="drop", retbins=True
+                    # )
+                    # 计算等宽分箱
+                    min_val = col.min().execute()
+                    max_val = col.max().execute()
+                    split_width = (max_val - min_val) / bin_num
+                    split_points = [
+                        min_val + i * split_width for i in range(1, bin_num)
+                    ]
+                else:
+                    raise ValueError(
+                        f"binning_method {self.binning_method} not supported"
+                    )
+
+                return {"type": "numeric", "split_points": split_points}
+
+        def _apply_feature_rule(tbl: ibis.Table, rule: dict):
+            col_name = rule["name"]
+            col = tbl[col_name]
+
+            split_points = rule["split_points"]
+            branches = []
+            if rule["type"] == "str":
+                branches = [(col == c, c) for c in split_points]
+            else:
+                branches = [(col < c, c) for c in split_points]
+                branches.append((col > split_points[-1], split_points[-1]))
+            bin_expr = ibis.cases(*branches)
+
+            nt = t.mutate(row_number=ibis.row_number().over())
+            nt = nt.select([col_name, "row_number", bin_expr.name("bin_index")])
+
+            na_index_df = nt.filter(col.isnull()).execute()
+            na_index = na_index_df["row_number"].to_numpy()
+
+            non_null_nt = nt.filter(col.notnull())
+            non_null_df = non_null_nt.execute()
+
+            grouped = non_null_df.groupby("bin_index")["row_number"].apply(list)
+            bin_indices = grouped.tolist()
+            return bin_indices, na_index
+
+        rules = {}
+        for col_name in features:
+            rule = _fit_feature_bins(col_name)
+            rule["name"] = col_name
+            rules[col_name] = rule
+
+        print(f"binning rules: {rules}")
+        for col_name, rule in rules.items():
+            bin_indices, na_index = _apply_feature_rule(t, rule)
+            print(f"use binning rule: {col_name} {bin_indices}, {na_index}")
+
+    def test_woe_binning(self):
+        pass
+
+    def test_sql(self):
+        schema = {
+            "date_id": "date",
+            "store_id": "int32",
+            "sold_amount": "double",
+            "quantity": "double",
+        }
+        catalog = {"tx": schema}
+        sql_str = "SELECT store_id, SUM(sold_amount) AS total FROM tx GROUP BY store_id"
+        expr = ibis.parse_sql(sql_str, catalog)
+
+        data = {
+            "date_id": pd.to_datetime(["2024-08-01", "2024-08-01", "2024-08-02"]),
+            "store_id": [1, 2, 1],
+            "sold_amount": [100.0, 200.0, 300.0],
+            "quantity": [1, 2, 3],
+        }
+        res = self._eval(expr, data, table_names=["tx"])
+        print(f"sql res:\n {res}")
+
+    def test_score_card(self):
+        predict_name: str = "pred"
+        predict_score_name: str = "predict_score"
+        scaled_value: float = 600
+        odd_base: float = 20.0
+        pdo: float = 20.0
+        positive: int = 1
+        min_score: float = 0.0
+        max_score: float = 1000.0
+
+        t = ibis.table(schema={"id": "str", "pred": "float"}, name="table")
+
+        factor = pdo / math.log(2)
+        offset = scaled_value - factor * math.log(odd_base)
+        pred = t[predict_name]
+        log_odds = factor * ((pred / (1 - pred)).log())
+        if positive == 1:
+            score = offset - log_odds
+        else:
+            score = offset + log_odds
+
+        new_col = ibis.ifelse(
+            score <= min_score,
+            min_score,
+            ibis.ifelse(score >= max_score, max_score, score),
+        )
+        exprs = {predict_score_name: new_col}
+        new_t = t.mutate(**exprs)
+        #
+        input = {
+            "id": ["id1", "id2"],
+            "pred": [0.1, 0.2],
+        }
+        res = self._eval(new_t, input)
+        print(f"score_card:\n {res}")
+        except_res = [576.959938, 553.561438]
+        npt.assert_allclose(res[predict_score_name], except_res)
+
+    @pytest.mark.parametrize(
+        "feature,op,bound_value",
+        [
+            ("a1", "==", "K1"),
+        ],
+    )
+    def test_condition_filter(self, feature, op, bound_value):
+        # step 1: compute row mask
+        schema = {"id": "str", "a1": "str", "a2": "str", "a3": "int", "a4": "float"}
+        t = ibis.table(schema, name="table")
+        col_dt = t.schema().fields[feature]
+        if col_dt.is_string():
+            value_type = str
+        elif col_dt.is_floating():
+            value_type = float
+        elif col_dt.is_integer():
+            value_type = int
+        else:
+            raise ValueError("only support INT, FLOAT, STRING for now")
+
+        value = None
+        if op != "NOTNULL":
+            if bound_value == "":
+                raise ValueError("bound_value is empty")
+            bound_value_list = bound_value.split(",")
+            values = [value_type(val) for val in bound_value_list]
+            value = values if op == "IN" else values[0]
+
+        col = t[feature]
+        if op == "==":
+            mask_expr = ibis.and_(col.notnull(), col == value)
+        elif op == "<":
+            mask_expr = ibis.and_(col.notnull(), col < value)
+        elif op == "<=":
+            mask_expr = ibis.and_(col.notnull(), col <= value)
+        elif op == ">":
+            mask_expr = ibis.and_(col.notnull(), col > value)
+        elif op == ">=":
+            mask_expr = ibis.and_(col.notnull(), col >= value)
+        elif op == "IN":
+            mask_expr = ibis.and_(col.notnull(), col.isin(value))
+        elif op == "NOTNULL":
+            mask_expr = col.notnull()
+        else:
+            raise ValueError(f"not support op: {op}")
+
+        new_t = t.mutate(mask=mask_expr).select("mask")
+
+        data = {
+            "id": ["1", "2", "3", "4"],
+            "a1": ["K5", "K1", None, "K6"],
+            "a2": ["A5", "A1", "A2", "A6"],
+            "a3": [5, 1, 2, 6],
+            "a4": [0, 1, 1, 0],
+        }
+        res = self._eval(new_t, data)
+
+        # step2: filter by row mask
+        # TODO: use ibis?
+        df = pd.DataFrame(data)
+        filterd_df = df[res["mask"]]
+        print(filterd_df)
+
+    @pytest.mark.parametrize("by", [["a"], ["a", "b"]])
+    @pytest.mark.parametrize(
+        "agg_pairs",
+        [
+            [("c", "sum")],
+            [("c", "count"), ("d", "sum")],
+        ],
+    )
+    def test_stat_groupby(self, by: list[str], agg_pairs: list[tuple[str, str]]):
+        data = {
+            "a": ["9", "6", "5", "5"],
+            "b": [5, 5, 6, 7],
+            "c": [1, 1, 2, 4],
+            "d": [11, 55, 1, 99],
+        }
+        schema = {"a": "str", "b": "int", "c": "float", "d": "int"}
+        t = ibis.table(schema=schema, name="table")
+
+        agg_map = {
+            "count": lambda x: x.count(),
+            "sum": lambda x: x.sum(),
+            "mean": lambda x: x.mean(),
+            "min": lambda x: x.min(),
+            "max": lambda x: x.max(),
+            "var": lambda x: x.var(),  # Variance
+        }
+
+        grouped = t.group_by(by)
+        aggs = []
+        for p in agg_pairs:
+            agg_col = p[0]
+            agg_fn = p[1]
+            if agg_fn not in agg_map:
+                raise ValueError(f"Unsupported aggregation function: {agg_fn}")
+            expr = agg_map[agg_fn](t[agg_col]).name(f"{agg_col}_{agg_fn}")
+            aggs.append(expr)
+
+        new_t = grouped.aggregate(aggs)
+        res = self._eval(new_t, data)
+        print(f"groupby: {by}\n {res}")
+
+    def test_stat_pearsonr(self):
+        pass
+
+    @pytest.mark.parametrize("features", [["a1", "a2"]])
+    def test_stat_vif(self, features: list[str]):
+        pass
+
+    def test_stat_psi(self):
+        pass
+
+    @pytest.mark.parametrize("features", [["a", "b", "c", "d", "f"]])
+    def test_stat_table_stats(self, features: list[str]):
+        # duckdb has impl skewness, register for ibis.
+        @ibis.udf.agg.builtin
+        def skewness(a: float) -> float:
+            """Compute the skewness."""
+
+        schema_pairs = {"a": "int", "b": "int", "c": "int", "d": "int", "f": "str"}
+        table = ibis.table(schema=schema_pairs, name="table")
+
+        def _compute_if(col_expr: ibis.Column, fn):
+            if not col_expr.type().is_string():
+                return fn(col_expr).cast("float64")
+            return ibis.null("float64")
+
+        def _central_moment(col: ibis.Column, k):
+            #  "t0"."c" - AVG("t0"."c") OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND...
+            mean_expr = col.mean()
+            return ((col - mean_expr) ** k).mean()
+
+        def get_stat_expr(col_expr: ibis.Column, order: int):
+            return ibis.struct({
+                "order": ibis.literal(order),
+                "column": ibis.literal(col_expr.get_name()),
+                "datatype": ibis.literal(str(col_expr.type())),
+                "nunique": col_expr.nunique(),
+                "count": col_expr.count(),
+                "count_na": col_expr.isnull().sum(),
+                "na_ratio": col_expr.isnull().sum() / col_expr.count(),
+                "min": _compute_if(col_expr, lambda c: c.min()),
+                "max": _compute_if(col_expr, lambda c: c.max()),
+                "mean": _compute_if(col_expr, lambda c: c.mean()),
+                "var": _compute_if(col_expr, lambda c: c.var()),
+                "std": _compute_if(col_expr, lambda c: c.std()),
+                "sem": _compute_if(col_expr, lambda c: c.std() / c.count().sqrt()),
+                "skew": _compute_if(col_expr, lambda c: skewness(c)),
+                "kurtosis": _compute_if(col_expr, lambda c: c.kurtosis()),
+                "q1": _compute_if(col_expr, lambda c: c.quantile(0.25)),
+                "q2": _compute_if(col_expr, lambda c: c.quantile(0.5)),
+                "q3": _compute_if(col_expr, lambda c: c.quantile(0.75)),
+                "moment_2": _compute_if(col_expr, lambda c: (c**2).mean()),
+                "moment_3": _compute_if(col_expr, lambda c: (c**3).mean()),
+                "moment_4": _compute_if(col_expr, lambda c: (c**4).mean()),
+                # "central_moment_2": _compute_if(
+                #     col_expr, lambda c: _central_moment(c, 2)
+                # ),
+                # "central_moment_3": _compute_if(
+                #     col_expr, lambda c: _central_moment(c, 3)
+                # ),
+                # "central_moment_4": _compute_if(
+                #     col_expr, lambda c: _central_moment(c, 4)
+                # ),
+                "sum": _compute_if(col_expr, lambda c: c.sum()),
+                "sum_2": _compute_if(col_expr, lambda c: (c**2).sum()),
+                "sum_3": _compute_if(col_expr, lambda c: (c**3).sum()),
+                "sum_4": _compute_if(col_expr, lambda c: (c**4).sum()),
+            }).name("stats")
+
+        stats_tables = []
+        for idx, col_name in enumerate(features):
+            col = table[col_name]
+            stat_expr = get_stat_expr(col, idx)
+            stats_table = table.aggregate([stat_expr])
+            stats_tables.append(stats_table)
+
+        result_expr = ibis.union(*stats_tables)
+        struct_fields = result_expr["stats"].type().names
+        mutations = {field: result_expr["stats"][field] for field in struct_fields}
+
+        result_expr = (
+            result_expr.mutate(**mutations)
+            .drop("stats")
+            .order_by("order")
+            .drop("order")
+        )
+
+        data = {
+            "a": [9, 6, 5, 5],
+            "b": [5, 5, 6, 7],
+            "c": [1, 1, 2, 4],
+            "d": [11, 55, 1, 99],
+            "f": ["hello", "world", "are you", "ok?"],
+        }
+        res = self._eval(result_expr, data)
+        print(f"table_stats: {features}\n {res}")
+
+    def _memtable(self, data: dict, schema, name: str = "table") -> ibis.Table:
+        return ibis.memtable(data, schema=schema, name=name)
+
+    def _eval(
+        self, expr: ibis.Table, *inputs: dict, table_names: list[str] | None = None
+    ) -> pd.DataFrame:
+        if table_names is None:
+            table_names = ["table"]
+
+        if _ibis_engine == "duckdb":
+            return self._eval_duckdb(expr, inputs, table_names)
+        else:
+            return self._eval_substrait(expr, inputs, table_names)
+
+    def _eval_duckdb(
+        self,
+        expr: ibis.Table,
+        inputs: list[dict],
+        table_names: list[str] | None = None,
+        udfs: list | None = None,
+    ):
+        if not table_names:
+            table_names = ["table"]
+        assert len(inputs) == len(table_names)
+
+        sql = ibis.to_sql(expr, dialect="duckdb")
+
+        print(f"eval sql: \n{sql}\n")
+
+        import duckdb
+        import pandas as pd
+
+        conn = duckdb.connect(":memory:")
+        for data, name in zip(inputs, table_names, strict=True):
+            df = pd.DataFrame(data)
+            conn.register(name, df)
+
+        if udfs:
+            for fn in udfs:
+                name = fn.__name__
+                conn.create_function(name, fn)
+
+        result_df = conn.execute(sql).fetchdf()
+        return result_df
+
+    def _eval_substrait(
+        self, expr: ibis.Table, inputs: list[dict], table_names: list[str] | None = None
+    ):
+        # You need to run cmd 'pip install ibis-substrait' manually.
+        # It will cause the ibis-framework version to roll back
+        import pyarrow as pa
+        import pyarrow.substrait as substrait  # noqa: F401
+        from ibis_substrait.compiler.core import SubstraitCompiler
+
+        assert len(inputs) == len(table_names)
+
+        # encode ir
+        compiler = SubstraitCompiler()
+        plan = compiler.compile(expr)
+        fn_txt = plan.SerializeToString()
+
+        # # decode ir
+        # substrait_plan = substrait.Plan()
+        # substrait_plan.ParseFromString(fn_txt)
+
+        # exec ir use pyarrow
+
+        tables = {
+            name: pa.Table.from_pydict(data)
+            for name, data in zip(table_names, inputs, strict=True)
+        }
+
+        def table_provider(names, schema):
+            if not names:
+                raise Exception("No names provided")
+            for name in names:
+                if name in tables:
+                    return tables[name]
+            raise Exception(f"Unrecognized table name, {names}, {table_names}")
+
+        reader = pa.substrait.run_query(fn_txt, table_provider=table_provider)
+        result = reader.read_all()
+        return result

--- a/tests/frontend/test_ibis_cc.py
+++ b/tests/frontend/test_ibis_cc.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import ibis
+
+from mplang.frontend import ibis_cc
+
+
+def test_ibis2sql():
+    table_name = "table"
+    in_tbl = ibis.table(schema={"a": "int", "b": "int", "c": "float"}, name=table_name)
+    result_expr = in_tbl["a"] + in_tbl["b"]
+    new_table = in_tbl.mutate(d=result_expr)
+    pfn = ibis_cc.ibis2sql(new_table, [in_tbl.schema()], [table_name])
+    assert pfn.fn_text is not None
+    assert "in_names" in pfn.attrs
+    assert len(pfn.ins_info) == 1 and len(pfn.outs_info) == 1
+    assert len(pfn.ins_info[0].columns) == 3
+    assert len(pfn.outs_info[0].columns) == 4


### PR DESCRIPTION
尝试增加ibis ir编译
- core/dtype: 增加str/object类型，TensorLike更像是np.ndarray,可以是object混合类型用于支持pd.DataFrame二维数据结构
- ibis ir使用sql作为中间表示，substrait也有尝试，但支持不是很完善，某些demo跑不过
- 后端使用duckdb作为执行引擎，输入一个np.ndarray的表，输出一个np.ndarray的表, 中间需要pd.DataFrame作为桥接duckdb.
  - 已知问题是：使用df存在一个问题是，需要全量数据在内存中，无法流式处理或者利用duckdb的能力。
- mplang/simp.py新增接口: prun_ibis, 给定输入表和执行表达式，返回一个输出表。
- 额外引入依赖: ibis-framework,duckdb,pandas
- tests/plib/test_ibis.py单测用于将sf中的预处理，尝试使用ibis来实现， 还有几个尚未实现。
  - 已知的是onehot/binning/woe_binning很难使用ibis预先生成表达式。