### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: static type check with Mypy
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/secretflow/mplang/security/code-scanning/2](https://github.com/secretflow/mplang/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code and runs static analysis, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
