### PR TITLE
feat: Enhance DType and MPType for relation support

### DIFF
--- a/mplang/core/base.py
+++ b/mplang/core/base.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
 from mplang.core.dtype import DType
 from mplang.core.mask import Mask
+from mplang.core.relation import RelationSchema
 
 # basic type aliases
 Rank = int
@@ -77,20 +79,11 @@ class TensorInfo:
         return f"Tensor<{shape_str}x{dtype_name}>" if shape_str else f"{dtype_name}"
 
 
-class MPContext(ABC):
-    """The context of an MPObject."""
+class MPKind(Enum):
+    """Enumeration for different kinds of MPType."""
 
-    @abstractmethod
-    def psize(self) -> int:
-        """Return the world size."""
-
-    @abstractmethod
-    def attrs(self) -> dict[str, Any]:
-        """Return the attributes of the context."""
-
-    def attr(self, key: str) -> Any:
-        """Return the attribute of the context by key."""
-        return self.attrs()[key]
+    TENSOR = auto()
+    RELATION = auto()
 
 
 class MPType:
@@ -98,28 +91,110 @@ class MPType:
 
     def __init__(
         self,
-        dtype: DType,
-        shape: Shape,
+        *,
+        kind: MPKind,
+        dtype: DType | None = None,
+        shape: Shape | None = None,
+        schema: RelationSchema | None = None,
         pmask: Mask | None = None,
         attrs: dict[str, Any] | None = None,
     ):
         """Initialize MPType.
 
         Args:
-            dtype: The data type of the object.
-            shape: The shape of the object, represented as a tuple of integers.
+            kind: The kind of MP type (TENSOR or RELATION).
+            dtype: The data type of the tensor (required for TENSOR kind).
+            shape: The shape of the tensor (required for TENSOR kind).
+            schema: The relational schema (required for RELATION kind).
             pmask: The party mask, used for compile/trace time determine which party holds the object.
             attrs: Attributes are key-value pairs that can be used to store additional information about the object.
         """
-        # Convert dtype to DType if needed
-        if not isinstance(dtype, DType):
-            dtype = DType.from_any(dtype)
-
-        self._dtype = dtype
-        self._shape = shape
+        self._kind = kind
         self._pmask = pmask
         # Ensure attrs is a copy
         self._attrs = copy.copy(attrs) if attrs is not None else {}
+
+        if kind == MPKind.TENSOR:
+            if dtype is None or shape is None:
+                raise ValueError("Tensor type requires dtype and shape")
+            # Convert dtype to DType if needed
+            if not isinstance(dtype, DType):
+                dtype = DType.from_any(dtype)
+            self._dtype = dtype
+            self._shape = shape
+            self._schema = None
+        elif kind == MPKind.RELATION:
+            if schema is None:
+                raise ValueError("Relation type requires schema")
+            self._schema = schema
+            self._dtype = None
+            self._shape = None
+        else:
+            raise ValueError(f"Unsupported MPKind: {kind}")
+
+    @classmethod
+    def tensor(
+        cls,
+        dtype: DType | Any,
+        shape: Shape,
+        pmask: Mask | None = None,
+        **attrs: Any,
+    ) -> MPType:
+        """Create a tensor type.
+
+        Args:
+            dtype: The data type of the tensor.
+            shape: The shape of the tensor.
+            pmask: The party mask.
+            **attrs: Additional attributes.
+
+        Returns:
+            MPType instance for tensor.
+
+        Raises:
+            ValueError: If dtype is relation-only.
+        """
+        # Convert dtype to DType if needed and validate
+        if not isinstance(dtype, DType):
+            dtype = DType.from_any(dtype)
+
+        # Ensure tensor types don't use relation-only dtypes
+        if dtype.is_relation_only:
+            raise ValueError(
+                f"Data type '{dtype.name}' is only supported in relations, "
+                f"not in tensors. Use relation types for string, date, and other "
+                f"non-numeric data types."
+            )
+
+        return cls(
+            kind=MPKind.TENSOR, dtype=dtype, shape=shape, pmask=pmask, attrs=attrs
+        )
+
+    @classmethod
+    def relation(
+        cls,
+        schema: RelationSchema | dict[str, DType],
+        pmask: Mask | None = None,
+        **attrs: Any,
+    ) -> MPType:
+        """Create a relation type.
+
+        Args:
+            schema: The relational schema or dict mapping column names to types.
+            pmask: The party mask.
+            **attrs: Additional attributes.
+
+        Returns:
+            MPType instance for relation.
+        """
+        if isinstance(schema, dict):
+            schema = RelationSchema.from_dict(schema)
+        return cls(kind=MPKind.RELATION, schema=schema, pmask=pmask, attrs=attrs)
+
+    @property
+    def kind(self) -> MPKind:
+        """The kind of this MPType (TENSOR or RELATION)."""
+        return self._kind
 
     @property
     def dtype(self) -> DType:
@@ -127,7 +202,12 @@ class MPType:
 
         This property is readonly (mandatory) and will be used for JAX compilation
         to determine the appropriate data type during trace and compilation phases.
+
+        Only available for tensor types.
         """
+        if self._kind != MPKind.TENSOR:
+            raise AttributeError("dtype is only available for tensor types")
+        assert self._dtype is not None  # Type guard
         return self._dtype
 
     @property
@@ -139,8 +219,24 @@ class MPType:
 
         This property is readonly (mandatory) and will be used for JAX compilation
         to determine tensor shapes during trace and compilation phases.
+
+        Only available for tensor types.
         """
+        if self._kind != MPKind.TENSOR:
+            raise AttributeError("shape is only available for tensor types")
+        assert self._shape is not None  # Type guard
         return self._shape
+
+    @property
+    def schema(self) -> RelationSchema:
+        """The relational schema.
+
+        Only available for relation types.
+        """
+        if self._kind != MPKind.RELATION:
+            raise AttributeError("schema is only available for relation types")
+        assert self._schema is not None  # Type guard
+        return self._schema
 
     @property
     def pmask(self) -> Mask | None:
@@ -183,20 +279,32 @@ class MPType:
     def __repr__(self) -> str:
         """String representation of MPType.
 
-        Schema: dtype[shape]<pmask>{other_attrs}
+        Schema:
+        - For tensor: dtype[shape]<pmask>{other_attrs}
+        - For relation: Relation<col1:type1, col2:type2><pmask>{other_attrs}
+
         Examples:
         - u64                        # scalar uint64
         - f32[3, 2]                 # 3x2 float32 tensor
         - f16[3]<3>                 # float16 vector with pmask=3
         - u32[5, 5]<F>{device="P0"} # uint32 matrix with pmask=15 and device attr
+        - Relation<id:i64, name:str> # relation with id and name columns
         """
-        # Start with short dtype name
-        ret = self._dtype.short_name()
+        if self._kind == MPKind.TENSOR:
+            # Start with short dtype name
+            assert self._dtype is not None
+            ret = self._dtype.short_name()
 
-        # Add shape if not scalar
-        if self._shape:
-            shape_str = ", ".join(str(d) for d in self._shape)
-            ret += f"[{shape_str}]"
+            # Add shape if not scalar
+            if self._shape:
+                shape_str = ", ".join(str(d) for d in self._shape)
+                ret += f"[{shape_str}]"
+        else:  # RELATION
+            assert self._schema is not None
+            cols = ", ".join(
+                f"{name}:{dtype.short_name()}" for name, dtype in self._schema.columns
+            )
+            ret = f"Relation<{cols}>"
 
         # Add pmask in angle brackets if present
         if self._pmask is not None:
@@ -219,8 +327,10 @@ class MPType:
         if not isinstance(other, MPType):
             return False
         return (
-            self._dtype == other._dtype
+            self._kind == other._kind
+            and self._dtype == other._dtype
             and self._shape == other._shape
+            and self._schema == other._schema
             and self._pmask == other._pmask
             and self._attrs == other._attrs
         )
@@ -229,16 +339,33 @@ class MPType:
         """Compute hash for MPType objects."""
         # Make attrs hashable by converting to frozenset of items
         attrs_hash = hash(frozenset(self._attrs.items())) if self._attrs else 0
-        return hash((self._dtype, self._shape, self._pmask, attrs_hash))
+        return hash((
+            self._kind,
+            self._dtype,
+            self._shape,
+            self._schema,
+            self._pmask,
+            attrs_hash,
+        ))
 
     def isInstance(self, obj: MPObject) -> bool:
         """Check if the given object is an instance of this MPType."""
         if not isinstance(obj, MPObject):
             return False
-        if obj.dtype != self._dtype:
+
+        # Check if the object's type matches this type
+        obj_type = obj.mptype
+        if self._kind != obj_type._kind:
             return False
-        if obj.shape != self._shape:
-            return False
+
+        if self._kind == MPKind.TENSOR:
+            if self._dtype != obj_type._dtype or self._shape != obj_type._shape:
+                return False
+        elif self._kind == MPKind.RELATION:
+            if self._schema != obj_type._schema:
+                return False
+
+        # Check attributes
         if self._attrs:
             if not isinstance(obj.attrs, dict):
                 return False
@@ -248,7 +375,13 @@ class MPType:
         return True
 
     def to_numpy(self) -> np.dtype:
-        """Convert to NumPy dtype for compatibility."""
+        """Convert to NumPy dtype for compatibility.
+
+        Only available for tensor types.
+        """
+        if self._kind != MPKind.TENSOR:
+            raise AttributeError("to_numpy is only available for tensor types")
+        assert self._dtype is not None
         return self._dtype.to_numpy()
 
     @classmethod
@@ -258,22 +391,84 @@ class MPType:
         pmask: Mask | None = None,
         **kwargs: Any,
     ) -> MPType:
+        """Create MPType from tensor-like object.
+
+        Args:
+            obj: Tensor-like object or scalar.
+            pmask: The party mask.
+            **kwargs: Additional attributes.
+
+        Returns:
+            MPType instance for tensor.
+        """
         attrs = copy.copy(kwargs)
         if isinstance(obj, ScalarType):
-            return cls(DType.from_python_type(type(obj)), (), pmask, attrs)
+            return cls.tensor(DType.from_python_type(type(obj)), (), pmask, **attrs)
         elif isinstance(obj, TensorLike):
-            return cls(DType.from_any(obj.dtype), obj.shape, pmask, attrs)
+            return cls.tensor(DType.from_any(obj.dtype), obj.shape, pmask, **attrs)
         elif isinstance(obj, list | tuple):
             # Convert lists/tuples to numpy arrays for compatibility
             arr = np.array(obj)
-            return cls(DType.from_any(arr.dtype), arr.shape, pmask, attrs)
+            return cls.tensor(DType.from_any(arr.dtype), arr.shape, pmask, **attrs)
         else:
             raise TypeError(f"Unsupported type: {type(obj)}.")
 
     @classmethod
     def from_mpobj(cls, obj: MPObject) -> MPType:
+        """Create MPType from MPObject.
+
+        Args:
+            obj: MPObject instance.
+
+        Returns:
+            MPType instance with same type as the object.
+        """
         # assume obj is MPObject-like
-        return cls(obj.dtype, obj.shape, obj.pmask, obj.attrs)
+        obj_type = obj.mptype
+        if obj_type.kind == MPKind.TENSOR:
+            return cls.tensor(obj.dtype, obj.shape, obj.pmask, **obj.attrs)
+        else:  # RELATION
+            return cls.relation(obj_type.schema, obj.pmask, **obj.attrs)
+
+    @classmethod
+    def from_obj(cls, obj: Any, pmask: Mask | None = None, **attrs: Any) -> MPType:
+        """Create MPType from any object, automatically inferring the type.
+
+        Args:
+            obj: Object to create type from.
+            pmask: The party mask.
+            **attrs: Additional attributes.
+
+        Returns:
+            MPType instance.
+
+        Raises:
+            TypeError: If object type cannot be inferred.
+            NotImplementedError: For relation objects (not yet implemented).
+        """
+        # Check if it's a relation-like object (e.g., pandas DataFrame, pyarrow Table)
+        if hasattr(obj, "schema") and hasattr(obj, "columns"):
+            # This would need specific implementation for different relation types
+            raise NotImplementedError("Relation object detection not implemented yet")
+
+        # Otherwise treat as tensor-like
+        return cls.from_tensor(obj, pmask, **attrs)
+
+
+class MPContext(ABC):
+    """The context of an MPObject."""
+
+    @abstractmethod
+    def psize(self) -> int:
+        """Return the world size."""
+
+    @abstractmethod
+    def attrs(self) -> dict[str, Any]:
+        """Return the attributes of the context."""
+
+    def attr(self, key: str) -> Any:
+        """Return the attribute of the context by key."""
+        return self.attrs()[key]
 
 
 class MPObject(ABC):
@@ -298,6 +493,14 @@ class MPObject(ABC):
         return self.mptype.shape
 
     @property
+    def schema(self) -> RelationSchema:
+        """The relational schema of the object.
+
+        Only available for relation types.
+        """
+        return self.mptype.schema
+
+    @property
     def pmask(self) -> Mask | None:
         return self.mptype.pmask
 
@@ -311,8 +514,9 @@ class MPObject(ABC):
         """Return the context of the object."""
 
 
-# Forword docstrings from MPType to MPObject
+# Forward docstrings from MPType to MPObject
 MPObject.dtype.__doc__ = MPType.dtype.__doc__
 MPObject.shape.__doc__ = MPType.shape.__doc__
+MPObject.schema.__doc__ = MPType.schema.__doc__
 MPObject.pmask.__doc__ = MPType.pmask.__doc__
 MPObject.attrs.__doc__ = MPType.attrs.__doc__

--- a/mplang/core/dtype.py
+++ b/mplang/core/dtype.py
@@ -38,6 +38,7 @@ class DType:
     is_signed: bool | None = None  # None for non-numeric types
     is_floating: bool = False
     is_complex: bool = False
+    is_relation_only: bool = False  # True for types only supported in relations
 
     def __post_init__(self) -> None:
         # Validate the dtype configuration
@@ -71,6 +72,19 @@ class DType:
             "float64": "f64",
             "complex64": "c64",
             "complex128": "c128",
+            # Relation-only types
+            "string": "str",
+            "text": "text",
+            "varchar": "varchar",
+            "char": "char",
+            "date": "date",
+            "time": "time",
+            "datetime": "datetime",
+            "timestamp": "timestamp",
+            "decimal": "decimal",
+            "binary": "binary",
+            "json": "json",
+            "uuid": "uuid",
         }
         return name_map.get(self.name, self.name)
 
@@ -88,6 +102,11 @@ class DType:
             return cls(name, np_dtype.itemsize * 8, True, True, False)
         elif np_dtype.kind == "c":  # complex
             return cls(name, np_dtype.itemsize * 8, True, True, True)
+        elif np_dtype.kind in ("U", "S"):  # unicode or byte string
+            # For strings, bitwidth represents max character/byte length
+            return cls(
+                name, np_dtype.itemsize, None, False, False, True
+            )  # relation-only
         else:
             raise ValueError(f"Unsupported NumPy dtype kind: {np_dtype.kind}")
 
@@ -186,6 +205,22 @@ FLOAT64 = DType("float64", 64, True, True, False)
 COMPLEX64 = DType("complex64", 64, True, True, True)
 COMPLEX128 = DType("complex128", 128, True, True, True)
 
+# Relation-only types (marked with is_relation_only=True)
+STRING = DType("string", 0, None, False, False, True)  # Variable length string
+TEXT = DType("text", 0, None, False, False, True)  # Large text
+VARCHAR = DType(
+    "varchar", 255, None, False, False, True
+)  # Variable char with max length
+CHAR = DType("char", 255, None, False, False, True)  # Fixed length char
+DATE = DType("date", 32, None, False, False, True)  # Date only
+TIME = DType("time", 32, None, False, False, True)  # Time only
+DATETIME = DType("datetime", 64, None, False, False, True)  # Date and time
+TIMESTAMP = DType("timestamp", 64, None, False, False, True)  # Timestamp with timezone
+DECIMAL = DType("decimal", 128, True, False, False, True)  # Arbitrary precision decimal
+BINARY = DType("binary", 0, None, False, False, True)  # Binary data
+JSON = DType("json", 0, None, False, False, True)  # JSON data
+UUID = DType("uuid", 128, None, False, False, True)  # UUID type
+
 
 # Helper functions for easy conversion
 
@@ -198,3 +233,37 @@ def from_numpy(np_dtype: Any) -> DType:
 def to_numpy(dtype: DType) -> np.dtype:
     """Convert custom DType to NumPy dtype."""
     return dtype.to_numpy()
+
+
+# Export all public types and constants
+__all__ = [
+    "BINARY",
+    "BOOL",
+    "CHAR",
+    "COMPLEX64",
+    "COMPLEX128",
+    "DATE",
+    "DATETIME",
+    "DECIMAL",
+    "FLOAT16",
+    "FLOAT32",
+    "FLOAT64",
+    "INT8",
+    "INT16",
+    "INT32",
+    "INT64",
+    "JSON",
+    "STRING",
+    "TEXT",
+    "TIME",
+    "TIMESTAMP",
+    "UINT8",
+    "UINT16",
+    "UINT32",
+    "UINT64",
+    "UUID",
+    "VARCHAR",
+    "DType",
+    "from_numpy",
+    "to_numpy",
+]

--- a/mplang/core/mpir.py
+++ b/mplang/core/mpir.py
@@ -690,7 +690,7 @@ class Reader:
         for attr_name, attr_proto in type_proto.attrs.items():
             attrs[attr_name] = self._proto_to_attr(attr_proto)
 
-        return MPType(dtype, shape, pmask, attrs)
+        return MPType.tensor(dtype, shape, pmask, **attrs)
 
     def _proto_to_attr(self, attr_proto: mpir_pb2.AttrProto) -> Any:
         """Convert AttrProto to Python value."""

--- a/mplang/core/relation.py
+++ b/mplang/core/relation.py
@@ -1,0 +1,154 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mplang.core.dtype import DType
+
+__all__ = ["RelationSchema"]
+
+
+@dataclass(frozen=True)
+class RelationSchema:
+    """Relational schema: ordered list of column name-type pairs.
+
+    Represents table structure in relational algebra, containing column names
+    and their corresponding data types.
+
+    Examples:
+        >>> schema = RelationSchema.from_dict({
+        ...     "id": DType.i64(),
+        ...     "name": DType.string(),
+        ... })
+        >>> schema = RelationSchema((("id", DType.i64()), ("name", DType.string())))
+    """
+
+    columns: tuple[tuple[str, DType], ...]
+
+    def __post_init__(self) -> None:
+        """Validate the relational schema."""
+        if not self.columns:
+            raise ValueError("RelationSchema cannot be empty")
+
+        # Validate column name uniqueness
+        names = [name for name, _ in self.columns]
+        if len(names) != len(set(names)):
+            raise ValueError("Column names must be unique")
+
+        # Validate column names are non-empty
+        for name, dtype in self.columns:
+            if not name or not isinstance(name, str):
+                raise ValueError("Column names must be non-empty strings")
+            if not isinstance(dtype, DType):
+                raise ValueError(f"Column type must be DType, got {type(dtype)}")
+
+    @classmethod
+    def from_dict(cls, schema_dict: dict[str, DType]) -> RelationSchema:
+        """Create relational schema from dictionary.
+
+        Args:
+            schema_dict: Mapping from column names to data types
+
+        Returns:
+            RelationSchema instance
+        """
+        return cls(tuple(schema_dict.items()))
+
+    @classmethod
+    def from_pairs(cls, pairs: list[tuple[str, DType]]) -> RelationSchema:
+        """Create relational schema from list of name-type pairs.
+
+        Args:
+            pairs: List of tuples containing column name and data type
+
+        Returns:
+            RelationSchema instance
+        """
+        return cls(tuple(pairs))
+
+    def column_names(self) -> tuple[str, ...]:
+        """Get all column names."""
+        return tuple(name for name, _ in self.columns)
+
+    def column_types(self) -> tuple[DType, ...]:
+        """Get all column data types."""
+        return tuple(dtype for _, dtype in self.columns)
+
+    def get_column_type(self, name: str) -> DType:
+        """Get data type by column name.
+
+        Args:
+            name: Column name
+
+        Returns:
+            Corresponding data type
+
+        Raises:
+            KeyError: If column name does not exist
+        """
+        for col_name, col_type in self.columns:
+            if col_name == name:
+                return col_type
+        raise KeyError(f"Column '{name}' not found in schema")
+
+    def has_column(self, name: str) -> bool:
+        """Check if contains specified column name.
+
+        Args:
+            name: Column name
+
+        Returns:
+            True if contains the column, False otherwise
+        """
+        return name in self.column_names()
+
+    def num_columns(self) -> int:
+        """Get number of columns."""
+        return len(self.columns)
+
+    def to_dict(self) -> dict[str, DType]:
+        """Convert to dictionary form."""
+        return dict(self.columns)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        cols = ", ".join(f"{name}:{dtype.short_name()}" for name, dtype in self.columns)
+        return f"RelationSchema<{cols}>"
+
+    def __len__(self) -> int:
+        """Get number of columns."""
+        return len(self.columns)
+
+    def __iter__(self):
+        """Support iteration."""
+        return iter(self.columns)
+
+    def __getitem__(self, index: int | str) -> tuple[str, DType] | DType:
+        """Support index access.
+
+        Args:
+            index: Integer index or column name
+
+        Returns:
+            If integer index, returns (column name, data type) tuple
+            If column name, returns corresponding data type
+        """
+        if isinstance(index, int):
+            return self.columns[index]
+        elif isinstance(index, str):
+            return self.get_column_type(index)
+        else:
+            raise TypeError(f"Index must be int or str, got {type(index)}")

--- a/mplang/expr/ast.py
+++ b/mplang/expr/ast.py
@@ -96,7 +96,7 @@ class RankExpr(Expr):
         self.pmask = pmask
 
     def _compute_mptypes(self) -> list[MPType]:
-        return [MPType(UINT64, (), self.pmask)]
+        return [MPType.tensor(UINT64, (), self.pmask)]
 
     def accept(self, visitor: ExprVisitor) -> Any:
         return visitor.visit_rank(self)
@@ -113,7 +113,7 @@ class ConstExpr(Expr):
 
     def _compute_mptypes(self) -> list[MPType]:
         # Constants are public and available to all parties.
-        return [MPType(self.typ.dtype, self.typ.shape, self.pmask)]
+        return [MPType.tensor(self.typ.dtype, self.typ.shape, self.pmask)]
 
     def accept(self, visitor: ExprVisitor) -> Any:
         return visitor.visit_const(self)
@@ -131,7 +131,7 @@ class RandExpr(Expr):
         self.pmask = pmask
 
     def _compute_mptypes(self) -> list[MPType]:
-        return [MPType(self.typ.dtype, self.typ.shape, self.pmask)]
+        return [MPType.tensor(self.typ.dtype, self.typ.shape, self.pmask)]
 
     def accept(self, visitor: ExprVisitor) -> Any:
         return visitor.visit_rand(self)
@@ -189,7 +189,7 @@ class EvalExpr(Expr):
 
         # Create result MPTypes based on PFunction output info
         result_types = [
-            MPType(out_info.dtype, out_info.shape, effective_pmask)
+            MPType.tensor(out_info.dtype, out_info.shape, effective_pmask)
             for out_info in self.pfunc.outs_info
         ]
         return result_types
@@ -340,7 +340,7 @@ class ConvExpr(Expr):
             else:
                 out_pmask = None
 
-        return [MPType(first.dtype, first.shape, out_pmask, first.attrs)]
+        return [MPType.tensor(first.dtype, first.shape, out_pmask, **first.attrs)]
 
     def accept(self, visitor: ExprVisitor) -> Any:
         return visitor.visit_conv(self)
@@ -422,7 +422,9 @@ class ShflSExpr(Expr):
     def _compute_mptypes(self) -> list[MPType]:
         # The types are the same as the source value, but with a new pmask.
         src_type = self.src_val.mptype
-        return [MPType(src_type.dtype, src_type.shape, self.pmask, src_type.attrs)]
+        return [
+            MPType.tensor(src_type.dtype, src_type.shape, self.pmask, **src_type.attrs)
+        ]
 
     def accept(self, visitor: ExprVisitor) -> Any:
         return visitor.visit_shfl_s(self)
@@ -444,7 +446,7 @@ class ShflExpr(Expr):
         result_types = []
         for src_type in src_types:
             result_types.append(
-                MPType(src_type.dtype, src_type.shape, None, src_type.attrs)
+                MPType.tensor(src_type.dtype, src_type.shape, None, **src_type.attrs)
             )
         return result_types
 

--- a/tests/core/test_mpir.py
+++ b/tests/core/test_mpir.py
@@ -108,7 +108,7 @@ class TestBasicExpressions:
 
     def test_variable_expr_roundtrip(self):
         """Test VariableExpr roundtrip."""
-        mptype = MPType(DType.from_numpy(np.float32), (3,), pmask=7)
+        mptype = MPType.tensor(DType.from_numpy(np.float32), (3,), pmask=7)
         original = VariableExpr("test_var", mptype)
 
         writer = Writer()
@@ -359,8 +359,10 @@ class TestComplexExpressions:
 
     def test_conv_expr_serialization(self):
         """Test ConvExpr serialization (write only)."""
-        mptype1 = MPType(DType.from_numpy(np.float32), (2,), pmask=3)  # Party 0 and 1
-        mptype2 = MPType(DType.from_numpy(np.float32), (2,), pmask=4)  # Party 2
+        mptype1 = MPType.tensor(
+            DType.from_numpy(np.float32), (2,), pmask=3
+        )  # Party 0 and 1
+        mptype2 = MPType.tensor(DType.from_numpy(np.float32), (2,), pmask=4)  # Party 2
         var1 = VariableExpr("x", mptype1)
         var2 = VariableExpr("y", mptype2)
 

--- a/tests/core/test_mptype.py
+++ b/tests/core/test_mptype.py
@@ -1,0 +1,224 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from mplang.core.base import MPKind, MPType
+from mplang.core.dtype import DATE, FLOAT32, FLOAT64, INT32, INT64, JSON, STRING
+from mplang.core.mask import Mask
+from mplang.core.relation import RelationSchema
+
+
+class TestMPType:
+    """Test MPType functionality with tensor and relation support."""
+
+    def test_tensor_creation(self):
+        """Test tensor MPType creation."""
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+
+        assert tensor_type.kind == MPKind.TENSOR
+        assert tensor_type.dtype == FLOAT32
+        assert tensor_type.shape == (3, 4)
+
+    def test_relation_creation(self):
+        """Test relation MPType creation."""
+        schema = RelationSchema.from_dict({
+            "user_id": INT64,
+            "score": FLOAT64,
+            "rank": INT32,
+        })
+
+        relation_type = MPType.relation(schema)
+
+        assert relation_type.kind == MPKind.RELATION
+        assert relation_type.schema == schema
+
+    def test_relation_creation_from_dict(self):
+        """Test relation MPType creation from dict."""
+        schema_dict = {"id": INT64, "value": FLOAT32}
+        relation_type = MPType.relation(schema_dict)
+
+        assert relation_type.kind == MPKind.RELATION
+        assert relation_type.schema.column_names() == ("id", "value")
+
+    def test_tensor_attribute_access(self):
+        """Test tensor attribute access."""
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+
+        # Should work
+        assert tensor_type.dtype == FLOAT32
+        assert tensor_type.shape == (3, 4)
+
+        # Should fail
+        with pytest.raises(
+            AttributeError, match="schema is only available for relation types"
+        ):
+            _ = tensor_type.schema
+
+    def test_relation_attribute_access(self):
+        """Test relation attribute access."""
+        schema = RelationSchema.from_dict({"id": INT64, "value": FLOAT32})
+        relation_type = MPType.relation(schema)
+
+        # Should work
+        assert relation_type.schema == schema
+
+        # Should fail
+        with pytest.raises(
+            AttributeError, match="dtype is only available for tensor types"
+        ):
+            _ = relation_type.dtype
+
+        with pytest.raises(
+            AttributeError, match="shape is only available for tensor types"
+        ):
+            _ = relation_type.shape
+
+    def test_relation_only_dtype_validation(self):
+        """Test that relation-only dtypes cannot be used in tensors."""
+        # STRING type should fail in tensor
+        with pytest.raises(
+            ValueError, match="Data type 'string' is only supported in relations"
+        ):
+            MPType.tensor(STRING, (10,))
+
+        # DATE type should fail in tensor
+        with pytest.raises(
+            ValueError, match="Data type 'date' is only supported in relations"
+        ):
+            MPType.tensor(DATE, (5, 5))
+
+        # JSON type should fail in tensor
+        with pytest.raises(
+            ValueError, match="Data type 'json' is only supported in relations"
+        ):
+            MPType.tensor(JSON, (3,))
+
+        # But should work in relations
+        schema = RelationSchema.from_dict({
+            "name": STRING,
+            "birth_date": DATE,
+            "metadata": JSON,
+        })
+        relation_type = MPType.relation(schema)
+        assert relation_type.kind == MPKind.RELATION
+
+    def test_mptype_with_pmask_and_attrs(self):
+        """Test MPType with pmask and attributes."""
+        # Test tensor with pmask and attrs
+        tensor_type = MPType.tensor(
+            INT32, (10,), pmask=Mask.from_int(0b1101), device="GPU", precision="high"
+        )
+
+        assert tensor_type.pmask == Mask.from_int(0b1101)
+        assert tensor_type.attrs["device"] == "GPU"
+        assert tensor_type.attrs["precision"] == "high"
+
+        # Test relation with pmask and attrs
+        schema = RelationSchema.from_dict({"col1": FLOAT32, "col2": INT64})
+        relation_type = MPType.relation(
+            schema, pmask=Mask.from_int(0b11), storage="distributed", format="parquet"
+        )
+
+        assert relation_type.pmask == Mask.from_int(0b11)
+        assert relation_type.attrs["storage"] == "distributed"
+        assert relation_type.attrs["format"] == "parquet"
+
+    def test_equality_and_hashing(self):
+        """Test equality and hashing."""
+        # Test tensor equality
+        t1 = MPType.tensor(FLOAT32, (2, 3))
+        t2 = MPType.tensor(FLOAT32, (2, 3))
+        t3 = MPType.tensor(FLOAT64, (2, 3))
+
+        assert t1 == t2
+        assert t1 != t3
+        assert hash(t1) == hash(t2)
+        assert hash(t1) != hash(t3)
+
+        # Test relation equality
+        schema1 = RelationSchema.from_dict({"a": INT32, "b": FLOAT32})
+        schema2 = RelationSchema.from_dict({"a": INT32, "b": FLOAT32})
+        schema3 = RelationSchema.from_dict({"a": INT64, "b": FLOAT32})
+
+        r1 = MPType.relation(schema1)
+        r2 = MPType.relation(schema2)
+        r3 = MPType.relation(schema3)
+
+        assert r1 == r2
+        assert r1 != r3
+        assert hash(r1) == hash(r2)
+        assert hash(r1) != hash(r3)
+
+        # Test tensor vs relation inequality
+        assert t1 != r1
+
+    def test_string_representation(self):
+        """Test string representation."""
+        # Test tensor representation
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+        tensor_str = str(tensor_type)
+        assert "f32[3, 4]" == tensor_str
+
+        # Test relation representation
+        schema = RelationSchema.from_dict({"id": INT64, "name": STRING})
+        relation_type = MPType.relation(schema)
+        relation_str = str(relation_type)
+        assert "Relation<id:i64, name:str>" == relation_str
+
+        # Test with pmask and attributes
+        tensor_with_attrs = MPType.tensor(
+            INT32, (10,), pmask=Mask.from_int(0b1101), device="GPU"
+        )
+        tensor_attrs_str = str(tensor_with_attrs)
+        assert "i32[10]<D>" in tensor_attrs_str
+        assert 'device="GPU"' in tensor_attrs_str
+
+    def test_to_numpy_tensor_only(self):
+        """Test to_numpy method only works for tensors."""
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+        numpy_dtype = tensor_type.to_numpy()
+        assert str(numpy_dtype) == "float32"
+
+        # Should fail for relations
+        schema = RelationSchema.from_dict({"id": INT64})
+        relation_type = MPType.relation(schema)
+        with pytest.raises(
+            AttributeError, match="to_numpy is only available for tensor types"
+        ):
+            relation_type.to_numpy()
+
+    def test_from_tensor_factory_method(self):
+        """Test from_tensor factory method."""
+        import numpy as np
+
+        # Test with scalar
+        scalar_type = MPType.from_tensor(42)
+        assert scalar_type.kind == MPKind.TENSOR
+        assert scalar_type.shape == ()
+
+        # Test with numpy array
+        arr = np.array([[1, 2], [3, 4]], dtype=np.float32)
+        array_type = MPType.from_tensor(arr)
+        assert array_type.kind == MPKind.TENSOR
+        assert array_type.dtype == FLOAT32
+        assert array_type.shape == (2, 2)
+
+        # Test with list converted to numpy array
+        import numpy as np
+
+        list_arr = np.array([1, 2, 3])
+        list_type = MPType.from_tensor(list_arr)
+        assert list_type.kind == MPKind.TENSOR
+        assert list_type.shape == (3,)

--- a/tests/core/test_relation.py
+++ b/tests/core/test_relation.py
@@ -1,0 +1,139 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from mplang.core.dtype import DATE, FLOAT32, INT32, INT64, JSON, STRING
+from mplang.core.relation import RelationSchema
+
+
+class TestRelationSchema:
+    """Test RelationSchema functionality."""
+
+    def test_creation_from_dict(self):
+        """Test creating RelationSchema from dictionary."""
+        schema = RelationSchema.from_dict({"id": INT64, "value": FLOAT32, "age": INT32})
+
+        assert len(schema) == 3
+        assert schema.num_columns() == 3
+        assert schema.column_names() == ("id", "value", "age")
+        assert schema.column_types() == (INT64, FLOAT32, INT32)
+
+    def test_creation_from_pairs(self):
+        """Test creating RelationSchema from pairs."""
+        pairs = [("id", INT64), ("name", STRING)]
+        schema = RelationSchema.from_pairs(pairs)
+
+        assert len(schema) == 2
+        assert schema.column_names() == ("id", "name")
+
+    def test_column_access(self):
+        """Test column access methods."""
+        schema = RelationSchema.from_dict({"id": INT64, "value": FLOAT32, "age": INT32})
+
+        # Test has_column
+        assert schema.has_column("id") is True
+        assert schema.has_column("email") is False
+
+        # Test get_column_type
+        assert schema.get_column_type("id") == INT64
+        assert schema.get_column_type("value") == FLOAT32
+
+        with pytest.raises(KeyError):
+            schema.get_column_type("nonexistent")
+
+    def test_indexing(self):
+        """Test indexing functionality."""
+        schema = RelationSchema.from_dict({"id": INT64, "value": FLOAT32})
+
+        # Test integer indexing
+        assert schema[0] == ("id", INT64)
+        assert schema[1] == ("value", FLOAT32)
+
+        # Test string indexing
+        assert schema["id"] == INT64
+        assert schema["value"] == FLOAT32
+
+        with pytest.raises(KeyError):
+            _ = schema["nonexistent"]
+
+    def test_iteration(self):
+        """Test iteration over schema."""
+        schema = RelationSchema.from_dict({"id": INT64, "value": FLOAT32})
+
+        columns = list(schema)
+        assert len(columns) == 2
+        assert columns[0] == ("id", INT64)
+        assert columns[1] == ("value", FLOAT32)
+
+    def test_to_dict(self):
+        """Test conversion back to dictionary."""
+        original_dict = {"id": INT64, "value": FLOAT32}
+        schema = RelationSchema.from_dict(original_dict)
+        result_dict = schema.to_dict()
+
+        assert result_dict == original_dict
+
+    def test_string_representation(self):
+        """Test string representation."""
+        schema = RelationSchema.from_dict({"id": INT64, "value": FLOAT32})
+
+        repr_str = repr(schema)
+        assert "RelationSchema<" in repr_str
+        assert "id:i64" in repr_str
+        assert "value:f32" in repr_str
+
+    def test_relation_only_types(self):
+        """Test schemas with relation-only data types."""
+        schema = RelationSchema.from_dict({
+            "name": STRING,
+            "birth_date": DATE,
+            "metadata": JSON,
+        })
+
+        assert schema.get_column_type("name") == STRING
+        assert schema.get_column_type("birth_date") == DATE
+        assert schema.get_column_type("metadata") == JSON
+
+    def test_validation(self):
+        """Test schema validation."""
+        # Test empty schema
+        with pytest.raises(ValueError, match="RelationSchema cannot be empty"):
+            RelationSchema(())
+
+        # Test duplicate column names
+        with pytest.raises(ValueError, match="Column names must be unique"):
+            RelationSchema((("id", INT64), ("id", FLOAT32)))
+
+        # Test invalid column names
+        with pytest.raises(ValueError, match="Column names must be non-empty strings"):
+            RelationSchema((("", INT64),))
+
+        # Invalid type should be caught by validation
+        with pytest.raises(ValueError, match="Column names must be non-empty strings"):
+            # This will be caught by __post_init__ validation
+            schema = RelationSchema.__new__(RelationSchema)
+            object.__setattr__(schema, "columns", ((None, INT64),))
+            schema.__post_init__()
+
+    def test_equality(self):
+        """Test schema equality."""
+        schema1 = RelationSchema.from_dict({"id": INT64, "value": FLOAT32})
+        schema2 = RelationSchema.from_dict({"id": INT64, "value": FLOAT32})
+        schema3 = RelationSchema.from_dict({"id": INT32, "value": FLOAT32})
+
+        assert schema1 == schema2
+        assert schema1 != schema3
+        assert hash(schema1) == hash(schema2)
+        assert hash(schema1) != hash(schema3)

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -78,7 +78,7 @@ def trace_context(mask_2p):
 @pytest.fixture
 def mock_mpobject(tensor_info_float, mask_2p):
     """Create a mock MPObject for testing."""
-    mptype = MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p)
+    mptype = MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p)
     return MockMPObject(mptype, "test_obj")
 
 
@@ -151,10 +151,11 @@ class TestTraceContext:
     ):
         """Test capturing different MPObjects."""
         obj1 = MockMPObject(
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p), "obj1"
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            "obj1",
         )
         obj2 = MockMPObject(
-            MPType(tensor_info_int.dtype, tensor_info_int.shape, mask_2p), "obj2"
+            MPType.tensor(tensor_info_int.dtype, tensor_info_int.shape, mask_2p), "obj2"
         )
 
         captured1 = trace_context.capture(obj1)
@@ -187,7 +188,7 @@ class TestTraceVar:
         """Test TraceVar initialization with single-output expression."""
         expr = VariableExpr(
             "test_var",
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
         )
         trace_var = TraceVar(trace_context, expr)
 
@@ -204,8 +205,8 @@ class TestTraceVar:
         # Create a mock expression with multiple outputs
         expr = Mock()
         expr.mptypes = [
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
         ]
 
         with pytest.raises(
@@ -217,7 +218,7 @@ class TestTraceVar:
         """Test TraceVar string representation."""
         expr = VariableExpr(
             "test_var",
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
         )
         trace_var = TraceVar(trace_context, expr)
 
@@ -452,10 +453,12 @@ class TestTrace:
         """Test tracing a function with multiple MPObject outputs."""
         # Create multiple mock objects
         obj1 = MockMPObject(
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p), "obj1"
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            "obj1",
         )
         obj2 = MockMPObject(
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p), "obj2"
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            "obj2",
         )
 
         def multi_output_func(x, y):
@@ -488,7 +491,7 @@ class TestTrace:
         """Test tracing a function that captures external variables."""
         # Create an external variable
         external_obj = MockMPObject(
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
             "external",
         )
 
@@ -499,7 +502,8 @@ class TestTrace:
             return captured
 
         input_obj = MockMPObject(
-            MPType(tensor_info_float.dtype, tensor_info_float.shape, mask_2p), "input"
+            MPType.tensor(tensor_info_float.dtype, tensor_info_float.shape, mask_2p),
+            "input",
         )
         traced_fn = trace(trace_context, capturing_func, input_obj)
 

--- a/tests/expr/test_ast.py
+++ b/tests/expr/test_ast.py
@@ -159,7 +159,7 @@ class TestVariableExpr:
 
     def test_type_computation(self, pmask_2p):
         """Test that variable expression returns the provided type."""
-        mptype = MPType(FLOAT32, (2, 3), pmask_2p)
+        mptype = MPType.tensor(FLOAT32, (2, 3), pmask_2p)
         expr = VariableExpr("param1", mptype)
 
         # VariableExpr should now return the provided type
@@ -169,7 +169,7 @@ class TestVariableExpr:
 
     def test_parameter_name(self, pmask_2p):
         """Test that parameter name is stored correctly."""
-        mptype = MPType(UINT64, (), pmask_2p)
+        mptype = MPType.tensor(UINT64, (), pmask_2p)
         expr = VariableExpr("test_param", mptype)
         assert expr.name == "test_param"
 
@@ -248,7 +248,7 @@ class TestFuncDefExpr:
     def test_identity_function(self, pmask_2p):
         """Test function definition expression with identity function."""
         # Create a variable expression for the function body
-        mptype = MPType(FLOAT32, (2, 3), pmask_2p)
+        mptype = MPType.tensor(FLOAT32, (2, 3), pmask_2p)
         root = VariableExpr("x", mptype)
 
         # Create function definition with string parameter
@@ -270,7 +270,7 @@ class TestCallExpr:
     def test_function_call(self, pmask_2p, tensor_info_2d):
         """Test function call expression."""
         # Create a function definition
-        mptype = MPType(FLOAT32, (2, 3), pmask_2p)
+        mptype = MPType.tensor(FLOAT32, (2, 3), pmask_2p)
         x_var = VariableExpr("x", mptype)
         func = FuncDefExpr(["x"], x_var)  # Identity function
 
@@ -299,7 +299,7 @@ class TestCondExpr:
         pred = ConstExpr(TensorInfo(INT32, ()), b"", pmask_2p)
 
         # Create then and else functions
-        mptype = MPType(FLOAT32, (2, 3), pmask_2p)
+        mptype = MPType.tensor(FLOAT32, (2, 3), pmask_2p)
         x_var = VariableExpr("x", mptype)
         then_fn = FuncDefExpr(["x"], x_var)  # Identity
         else_fn = FuncDefExpr(["x"], x_var)  # Identity
@@ -326,7 +326,7 @@ class TestWhileExpr:
     def test_while_loop(self, pmask_2p, tensor_info_2d):
         """Test while loop expression."""
         # Create condition and body functions
-        mptype = MPType(FLOAT32, (2, 3), pmask_2p)
+        mptype = MPType.tensor(FLOAT32, (2, 3), pmask_2p)
         x_var = VariableExpr("x", mptype)
         cond_fn = FuncDefExpr(["x"], ConstExpr(TensorInfo(INT32, ()), b"", pmask_2p))
         body_fn = FuncDefExpr(["x"], x_var)  # Identity

--- a/tests/expr/test_printer.py
+++ b/tests/expr/test_printer.py
@@ -107,7 +107,7 @@ class TestPrinterExpressions:
         printer = Printer(compact_format=False)
         from mplang.core.base import MPType
 
-        mptype = MPType(FLOAT32, (2, 2), pmask_2p)
+        mptype = MPType.tensor(FLOAT32, (2, 2), pmask_2p)
         expr = VariableExpr("test_var", mptype)
 
         result = printer.print_expr(expr)
@@ -269,8 +269,8 @@ class TestPrinterExpressions:
         # Create a function body that actually uses the parameters
         from mplang.core.base import MPType
 
-        x_mptype = MPType(FLOAT32, (1,), pmask_2p)
-        y_mptype = MPType(FLOAT32, (1,), pmask_2p)
+        x_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
+        y_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
 
         x_var = VariableExpr("x", x_mptype)
         y_var = VariableExpr("y", y_mptype)
@@ -307,7 +307,7 @@ class TestPrinterComplexExpressions:
         # Create then function that actually uses the parameter 'x'
         from mplang.core.base import MPType
 
-        x_mptype = MPType(FLOAT32, (1,), pmask_2p)
+        x_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
         x_var = VariableExpr("x", x_mptype)  # Reference the parameter
         then_fn = FuncDefExpr(["x"], x_var)
 
@@ -372,7 +372,7 @@ class TestPrinterComplexExpressions:
         )
 
         # 6. Function definition and call
-        param_type = MPType(FLOAT32, (2,), pmask_2p)
+        param_type = MPType.tensor(FLOAT32, (2,), pmask_2p)
         var_expr = VariableExpr("input_data", param_type)
         func_body = TupleExpr([var_expr, access_expr])
         func_def = FuncDefExpr(["input_data"], func_body)
@@ -457,7 +457,7 @@ class TestPrinterComplexExpressions:
         # Create condition function that uses the 'state' parameter
         from mplang.core.base import MPType
 
-        state_mptype = MPType(FLOAT32, (1,), pmask_2p)
+        state_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
         state_var = VariableExpr("state", state_mptype)
         # Access the first element of state to check if we should continue
         cond_body = AccessExpr(state_var, 0)
@@ -500,8 +500,8 @@ class TestPrinterComplexExpressions:
         # Create function body that actually uses the parameters
         from mplang.core.base import MPType
 
-        x_mptype = MPType(FLOAT32, (1,), pmask_2p)
-        y_mptype = MPType(FLOAT32, (1,), pmask_2p)
+        x_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
+        y_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
 
         x_var = VariableExpr("x", x_mptype)
         y_var = VariableExpr("y", y_mptype)
@@ -643,8 +643,8 @@ class TestPrinterEdgeCases:
         # Create nested function definitions with meaningful parameter usage
         from mplang.core.base import MPType
 
-        inner_param_type = MPType(FLOAT32, (1,), pmask_2p)
-        middle_param_type = MPType(FLOAT32, (1,), pmask_2p)
+        inner_param_type = MPType.tensor(FLOAT32, (1,), pmask_2p)
+        middle_param_type = MPType.tensor(FLOAT32, (1,), pmask_2p)
 
         # Inner function: takes parameter and accesses its first element
         inner_param = VariableExpr("inner_param", inner_param_type)
@@ -761,7 +761,7 @@ class TestPrinterMeaningfulParameterUsage:
         from mplang.core.base import MPType
 
         # Scenario 1: Parameter used in conditional predicate
-        param_type = MPType(FLOAT32, (2,), pmask_2p)
+        param_type = MPType.tensor(FLOAT32, (2,), pmask_2p)
         param_var = VariableExpr("data", param_type)
 
         # Use parameter in both branches - return the same parameter
@@ -800,7 +800,7 @@ class TestPrinterMeaningfulParameterUsage:
         from mplang.core.base import MPType
 
         # Create a function that uses the same parameter multiple times
-        param_type = MPType(FLOAT32, (1,), pmask_2p)
+        param_type = MPType.tensor(FLOAT32, (1,), pmask_2p)
         x_var = VariableExpr("x", param_type)
 
         # Use x multiple times: tuple x with itself
@@ -826,7 +826,7 @@ class TestPrinterMeaningfulParameterUsage:
         from mplang.core.base import MPType
 
         # Create a while loop that actually processes the state
-        state_type = MPType(FLOAT32, (3,), pmask_2p)
+        state_type = MPType.tensor(FLOAT32, (3,), pmask_2p)
         state_var = VariableExpr("state", state_type)
 
         # Condition: check if state[0] is non-zero (simplified)

--- a/tests/runtime/test_simulation.py
+++ b/tests/runtime/test_simulation.py
@@ -62,7 +62,7 @@ class TestSimVar:
     def test_simvar_creation(self, simulator):
         """Test SimVar creation and properties."""
         # Create a simple MPType
-        mptype = MPType(dtype=INT32, shape=(2, 3), pmask=Mask(3))
+        mptype = MPType.tensor(dtype=INT32, shape=(2, 3), pmask=Mask(3))
 
         # Create values for both parties
         values = [
@@ -80,7 +80,7 @@ class TestSimVar:
 
     def test_simvar_repr(self, simulator):
         """Test SimVar string representation."""
-        mptype = MPType(dtype=FLOAT32, shape=(2,), pmask=Mask(3))
+        mptype = MPType.tensor(FLOAT32, (2,), Mask(3))
         values = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
 
         simvar = SimVar(simulator, mptype, values)
@@ -175,7 +175,7 @@ class TestSimulator:
             return x
 
         # Create input variable
-        mptype = MPType(dtype=INT32, shape=(2,), pmask=Mask(3))
+        mptype = MPType.tensor(INT32, (2,), Mask(3))
         input_values = [
             np.array([1, 2], dtype=np.int32),
             np.array([3, 4], dtype=np.int32),
@@ -251,7 +251,7 @@ class TestSimulator:
         sim2 = Simulator(psize=2)
 
         # Create a variable in sim1
-        mptype = MPType(dtype=INT32, shape=(1,), pmask=Mask(3))
+        mptype = MPType.tensor(INT32, (1,), Mask(3))
         var_sim1 = SimVar(sim1, mptype, [np.array([1]), np.array([2])])
 
         # Create a simple expression


### PR DESCRIPTION
- Added `is_relation_only` attribute to DType to indicate types supported only in relations.
- Updated DType mappings to include relation-only types such as STRING, DATE, and JSON.
- Introduced RelationSchema class to represent relational schemas with validation for column names and types.
- Modified MPType to support tensor and relation types, including factory methods for creating instances.
- Updated tests to cover new functionality in DType, MPType, and RelationSchema, ensuring proper handling of relation-only types.
- Refactored existing tests to utilize the new MPType tensor creation method.