### PR TITLE
Refactor core module imports and introduce new MPObject and MPType cl…

### DIFF
--- a/mplang/api.py
+++ b/mplang/api.py
@@ -19,9 +19,10 @@ from typing import Any
 
 from jax.tree_util import tree_map
 
-from mplang.core.base import Mask, MPContext, MPObject
 from mplang.core.context_mgr import cur_ctx, with_ctx
 from mplang.core.interp import InterpContext
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPContext, MPObject
 from mplang.core.trace import TraceContext, TracedFunction, trace
 
 

--- a/mplang/backend/builtin.py
+++ b/mplang/backend/builtin.py
@@ -16,7 +16,7 @@ import os
 
 import numpy as np
 
-from mplang.core.base import TensorLike
+from mplang.core.mptype import TensorLike
 from mplang.core.pfunc import PFunction, PFunctionHandler
 
 

--- a/mplang/backend/spu.py
+++ b/mplang/backend/spu.py
@@ -21,7 +21,7 @@ import numpy as np
 import spu.api as spu_api
 import spu.libspu as libspu
 
-from mplang.core.base import TensorLike
+from mplang.core.mptype import TensorLike
 from mplang.core.pfunc import PFunction, PFunctionHandler
 from mplang.runtime.grpc_comm import LinkCommunicator
 

--- a/mplang/backend/stablehlo.py
+++ b/mplang/backend/stablehlo.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jax._src import xla_bridge
 from jax.lib import xla_client as xc
 
-from mplang.core.base import TensorLike
+from mplang.core.mptype import TensorLike
 from mplang.core.pfunc import PFunction, PFunctionHandler
 
 

--- a/mplang/core/comm.py
+++ b/mplang/core/comm.py
@@ -18,7 +18,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
-from mplang.core.base import Mask
+from mplang.core.mask import Mask
 
 
 class ICommunicator(ABC):

--- a/mplang/core/context_mgr.py
+++ b/mplang/core/context_mgr.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Imported only for typing to avoid import cycles at runtime.
-    from mplang.core.base import MPContext
+    from mplang.core.mpobject import MPContext
 
 # The global working context.
 _g_ctx: MPContext | None = None

--- a/mplang/core/interp.py
+++ b/mplang/core/interp.py
@@ -26,7 +26,8 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from typing import Any, cast
 
-from mplang.core.base import MPContext, MPObject, MPType, TensorLike
+from mplang.core.mpobject import MPContext, MPObject
+from mplang.core.mptype import MPType, TensorLike
 from mplang.core.trace import TracedFunction
 from mplang.expr.ast import Expr, VariableExpr
 from mplang.utils.func_utils import var_demorph, var_morph

--- a/mplang/core/mpir.py
+++ b/mplang/core/mpir.py
@@ -19,9 +19,9 @@ from typing import Any
 import numpy as np
 import spu.libspu as spu_api
 
-from mplang.core.base import MPType, TensorInfo
 from mplang.core.dtype import DType
 from mplang.core.mask import Mask
+from mplang.core.mptype import MPType, TensorInfo
 from mplang.core.pfunc import PFunction
 from mplang.expr import Expr, ExprVisitor, FuncDefExpr
 from mplang.expr.ast import (

--- a/mplang/core/mpobject.py
+++ b/mplang/core/mpobject.py
@@ -34,9 +34,9 @@ class MPContext(ABC):
     def attrs(self) -> dict[str, Any]:
         """Return the attributes of the context."""
 
-    def attr(self, key: str) -> Any:
+    def attr(self, key: str, default: Any = None) -> Any:
         """Return the attribute of the context by key."""
-        return self.attrs()[key]
+        return self.attrs().get(key, default)
 
 
 class MPObject(ABC):

--- a/mplang/core/mpobject.py
+++ b/mplang/core/mpobject.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from mplang.core.dtype import DType
+from mplang.core.mask import Mask
+from mplang.core.mptype import MPType, Shape
+from mplang.core.relation import RelationSchema
+
+
+class MPContext(ABC):
+    """The context of an MPObject."""
+
+    @abstractmethod
+    def psize(self) -> int:
+        """Return the world size."""
+
+    @abstractmethod
+    def attrs(self) -> dict[str, Any]:
+        """Return the attributes of the context."""
+
+    def attr(self, key: str) -> Any:
+        """Return the attribute of the context by key."""
+        return self.attrs()[key]
+
+
+class MPObject(ABC):
+    """The base class for all objects in mp-system."""
+
+    @property
+    @abstractmethod
+    def mptype(self) -> MPType:
+        """The type information of the object.
+
+        This property is readonly (mandatory) and will be used for JAX compilation
+        to determine the appropriate data type during trace and compilation phases.
+        MPType can be passed between different MPObjects as a value.
+        """
+
+    @property
+    def dtype(self) -> DType:
+        return self.mptype.dtype
+
+    @property
+    def shape(self) -> Shape:
+        return self.mptype.shape
+
+    @property
+    def schema(self) -> RelationSchema:
+        """The relational schema of the object.
+
+        Only available for relation types.
+        """
+        return self.mptype.schema
+
+    @property
+    def pmask(self) -> Mask | None:
+        return self.mptype.pmask
+
+    @property
+    def attrs(self) -> dict[str, Any]:
+        return self.mptype.attrs
+
+    @property
+    @abstractmethod
+    def ctx(self) -> MPContext:
+        """Return the context of the object."""
+
+
+# Forward docstrings from MPType to MPObject
+MPObject.dtype.__doc__ = MPType.dtype.__doc__
+MPObject.shape.__doc__ = MPType.shape.__doc__
+MPObject.schema.__doc__ = MPType.schema.__doc__
+MPObject.pmask.__doc__ = MPType.pmask.__doc__
+MPObject.attrs.__doc__ = MPType.attrs.__doc__

--- a/mplang/core/mptype.py
+++ b/mplang/core/mptype.py
@@ -360,8 +360,7 @@ class MPType:
     def isInstance(self, obj: MPObject) -> bool:
         """Check if the given object is an instance of this MPType."""
         # Import here to avoid circular import
-    def isInstance(self, obj: "MPObject") -> bool:
-        """Check if the given object is an instance of this MPType."""
+        from mplang.core.mpobject import MPObject
 
         if not isinstance(obj, MPObject):
             return False

--- a/mplang/core/mptype.py
+++ b/mplang/core/mptype.py
@@ -360,7 +360,8 @@ class MPType:
     def isInstance(self, obj: MPObject) -> bool:
         """Check if the given object is an instance of this MPType."""
         # Import here to avoid circular import
-        from mplang.core.mpobject import MPObject
+    def isInstance(self, obj: "MPObject") -> bool:
+        """Check if the given object is an instance of this MPType."""
 
         if not isinstance(obj, MPObject):
             return False

--- a/mplang/core/pfunc.py
+++ b/mplang/core/pfunc.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from types import MappingProxyType
 from typing import Any
 
-from mplang.core.base import TensorInfo, TensorLike
+from mplang.core.mptype import TensorInfo, TensorLike
 
 
 class PFunction:

--- a/mplang/core/primitive.py
+++ b/mplang/core/primitive.py
@@ -28,19 +28,12 @@ from typing import Any, ParamSpec, TypeVar, cast
 
 from jax.tree_util import tree_map
 
-from mplang.core.base import (
-    Mask,
-    MPContext,
-    MPObject,
-    Rank,
-    ScalarType,
-    Shape,
-    TensorInfo,
-    TensorLike,
-)
 from mplang.core.context_mgr import cur_ctx
 from mplang.core.dtype import UINT64
 from mplang.core.interp import InterpContext, InterpVar, apply
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPContext, MPObject
+from mplang.core.mptype import Rank, ScalarType, Shape, TensorInfo, TensorLike
 from mplang.core.pfunc import PFunction
 from mplang.core.trace import TraceContext, TraceVar, trace
 from mplang.expr.ast import (

--- a/mplang/core/trace.py
+++ b/mplang/core/trace.py
@@ -60,8 +60,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
-from mplang.core.base import Mask, MPContext, MPObject, MPType
 from mplang.core.context_mgr import with_ctx
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPContext, MPObject
+from mplang.core.mptype import MPType
 from mplang.core.pfunc import get_fn_name
 from mplang.expr.ast import Expr, FuncDefExpr, TupleExpr, VariableExpr
 from mplang.expr.printer import Printer

--- a/mplang/device.py
+++ b/mplang/device.py
@@ -32,9 +32,10 @@ from jax.tree_util import tree_map
 
 import mplang.api as mapi
 from mplang import mpi, simp, smpc
-from mplang.core.base import Mask, MPObject
 from mplang.core.context_mgr import set_ctx
 from mplang.core.interp import InterpContext
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPObject
 from mplang.core.primitive import primitive
 from mplang.runtime.driver import ExecutorDriver
 from mplang.runtime.simulation import Simulator

--- a/mplang/expr/ast.py
+++ b/mplang/expr/ast.py
@@ -26,8 +26,9 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from mplang.core.base import Mask, MPType, Rank, TensorInfo
 from mplang.core.dtype import UINT64
+from mplang.core.mask import Mask
+from mplang.core.mptype import MPType, Rank, TensorInfo
 from mplang.core.pfunc import PFunction
 from mplang.expr.utils import deduce_mask
 

--- a/mplang/expr/evaluator.py
+++ b/mplang/expr/evaluator.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from mplang.core.base import Mask
 from mplang.core.comm import ICommunicator
+from mplang.core.mask import Mask
 from mplang.core.pfunc import PFunction, PFunctionHandler
 from mplang.expr.ast import (
     AccessExpr,

--- a/mplang/expr/utils.py
+++ b/mplang/expr/utils.py
@@ -18,7 +18,8 @@ Utility functions for expression system.
 
 from collections.abc import Sequence
 
-from mplang.core.base import Mask, TensorLike
+from mplang.core.mask import Mask
+from mplang.core.mptype import TensorLike
 
 
 def type_equal(*args: TensorLike) -> bool:

--- a/mplang/frontend/builtin.py
+++ b/mplang/frontend/builtin.py
@@ -16,7 +16,8 @@ from typing import Any
 
 from jax.tree_util import PyTreeDef, tree_flatten
 
-from mplang.core.base import MPObject, TensorInfo
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import TensorInfo
 from mplang.core.pfunc import PFunction
 
 

--- a/mplang/frontend/jax_cc.py
+++ b/mplang/frontend/jax_cc.py
@@ -21,7 +21,8 @@ import jax
 import jax.numpy as jnp
 from jax.tree_util import PyTreeDef, tree_flatten
 
-from mplang.core.base import MPObject, TensorInfo
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import TensorInfo
 from mplang.core.pfunc import PFunction, get_fn_name
 from mplang.utils.func_utils import normalize_fn
 

--- a/mplang/frontend/spu.py
+++ b/mplang/frontend/spu.py
@@ -24,7 +24,7 @@ import spu.utils.frontend as spu_fe
 from jax import ShapeDtypeStruct
 from jax.tree_util import PyTreeDef, tree_flatten
 
-from mplang.core.base import TensorInfo, TensorLike
+from mplang.core.mptype import TensorInfo, TensorLike
 from mplang.core.pfunc import PFunction, get_fn_name
 from mplang.utils.func_utils import normalize_fn
 

--- a/mplang/mpi.py
+++ b/mplang/mpi.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import logging
 
 import mplang.core.primitive as prim
-from mplang.core.base import Mask, MPObject, Rank
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import Rank
 
 
 # scatter :: [m a] -> m Rank -> m a

--- a/mplang/random.py
+++ b/mplang/random.py
@@ -23,7 +23,8 @@ from jax.typing import ArrayLike
 
 import mplang.core.primitive as prim
 from mplang import simp
-from mplang.core.base import MPObject, Shape
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import Shape
 
 
 @prim.function

--- a/mplang/runtime/driver.py
+++ b/mplang/runtime/driver.py
@@ -30,9 +30,11 @@ import cloudpickle as pickle
 import grpc
 import spu.libspu as libspu
 
-from mplang.core.base import Mask, MPObject, MPType, Rank
 from mplang.core.interp import InterpContext, InterpVar
+from mplang.core.mask import Mask
 from mplang.core.mpir import Writer
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import MPType, Rank
 from mplang.expr.ast import Expr
 from mplang.protos import executor_pb2, executor_pb2_grpc
 from mplang.runtime.executor.resource import SessionName, SymbolName

--- a/mplang/runtime/executor/launcher.py
+++ b/mplang/runtime/executor/launcher.py
@@ -25,7 +25,7 @@ import functools
 import operator
 from collections.abc import Callable
 
-from mplang.core.base import Mask
+from mplang.core.mask import Mask
 from mplang.device import DeviceContext, parse_device_conf
 
 # Re-export client components

--- a/mplang/runtime/executor/server.py
+++ b/mplang/runtime/executor/server.py
@@ -37,7 +37,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from mplang.backend.builtin import BuiltinHandler
 from mplang.backend.spu import SpuHandler
 from mplang.backend.stablehlo import StablehloHandler
-from mplang.core.base import Mask
+from mplang.core.mask import Mask
 from mplang.core.mpir import Reader
 from mplang.expr.evaluator import Evaluator
 from mplang.protos import executor_pb2, executor_pb2_grpc, mpir_pb2

--- a/mplang/runtime/simulation.py
+++ b/mplang/runtime/simulation.py
@@ -26,9 +26,11 @@ import spu.libspu as libspu
 from mplang.backend.builtin import BuiltinHandler
 from mplang.backend.spu import SpuHandler
 from mplang.backend.stablehlo import StablehloHandler
-from mplang.core.base import Mask, MPObject, MPType, TensorLike
 from mplang.core.interp import InterpContext, InterpVar
+from mplang.core.mask import Mask
 from mplang.core.mpir import Reader, Writer
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import MPType, TensorLike
 from mplang.expr.ast import Expr
 from mplang.expr.evaluator import Evaluator
 from mplang.runtime.grpc_comm import LinkCommunicator

--- a/mplang/simp.py
+++ b/mplang/simp.py
@@ -19,7 +19,9 @@ from functools import partial
 from typing import Any
 
 from mplang.core import primitive as prim
-from mplang.core.base import Mask, MPObject, Rank, ScalarType, Shape, TensorLike
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import Rank, ScalarType, Shape, TensorLike
 from mplang.core.pfunc import PFunction
 from mplang.frontend import builtin, jax_cc
 

--- a/mplang/smpc.py
+++ b/mplang/smpc.py
@@ -23,8 +23,10 @@ from jax.tree_util import tree_unflatten
 
 import mplang.mpi as mpi
 from mplang.core import primitive as prim
-from mplang.core.base import Mask, MPObject, Rank
 from mplang.core.context_mgr import cur_ctx
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import Rank
 from mplang.frontend.spu import SpuFE, Visibility
 
 

--- a/tests/backend/test_builtin.py
+++ b/tests/backend/test_builtin.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 from mplang.backend.builtin import BuiltinHandler
-from mplang.core.base import TensorInfo
+from mplang.core.mptype import TensorInfo
 from mplang.core.pfunc import PFunction
 
 

--- a/tests/backend/test_spu.py
+++ b/tests/backend/test_spu.py
@@ -20,7 +20,7 @@ import spu.api as spu_api
 import spu.libspu as libspu
 
 from mplang.backend.spu import SpuHandler, SpuValue
-from mplang.core.base import TensorInfo
+from mplang.core.mptype import TensorInfo
 from mplang.frontend.spu import SpuFE
 from mplang.runtime.grpc_comm import LinkCommunicator
 

--- a/tests/backend/test_stablehlo.py
+++ b/tests/backend/test_stablehlo.py
@@ -20,7 +20,7 @@ import pytest
 from jax.tree_util import tree_flatten, tree_unflatten
 
 from mplang.backend.stablehlo import StablehloHandler
-from mplang.core.base import TensorInfo
+from mplang.core.mptype import TensorInfo
 from mplang.core.pfunc import PFunction
 from mplang.frontend import jax_cc
 

--- a/tests/core/test_dtype.py
+++ b/tests/core/test_dtype.py
@@ -15,7 +15,6 @@
 import numpy as np
 import pytest
 
-from mplang.core.base import MPType, TensorInfo
 from mplang.core.dtype import (
     BOOL,
     COMPLEX64,
@@ -35,6 +34,7 @@ from mplang.core.dtype import (
 )
 from mplang.core.mask import Mask
 from mplang.core.mpir import dtype_to_proto
+from mplang.core.mptype import MPType, TensorInfo
 
 try:
     import jax.numpy as jnp

--- a/tests/core/test_mpir.py
+++ b/tests/core/test_mpir.py
@@ -16,9 +16,9 @@
 import numpy as np
 import pytest
 
-from mplang.core.base import MPType, TensorInfo
 from mplang.core.dtype import DType
 from mplang.core.mpir import Reader, Writer
+from mplang.core.mptype import MPType, TensorInfo
 from mplang.core.pfunc import PFunction
 from mplang.expr import Expr
 from mplang.expr.ast import (

--- a/tests/core/test_mptype.py
+++ b/tests/core/test_mptype.py
@@ -15,9 +15,9 @@
 import numpy as np
 import pytest
 
-from mplang.core.base import MPKind, MPType
 from mplang.core.dtype import DATE, FLOAT32, FLOAT64, INT32, INT64, JSON, STRING
 from mplang.core.mask import Mask
+from mplang.core.mptype import MPKind, MPType
 from mplang.core.relation import RelationSchema
 
 

--- a/tests/core/test_primitive.py
+++ b/tests/core/test_primitive.py
@@ -28,9 +28,10 @@ import numpy as np
 import pytest
 
 from mplang import simp
-from mplang.core.base import Mask, Rank, TensorInfo
 from mplang.core.context_mgr import cur_ctx, with_ctx
 from mplang.core.dtype import FLOAT32, UINT64
+from mplang.core.mask import Mask
+from mplang.core.mptype import Rank, TensorInfo
 from mplang.core.primitive import (
     _switch_ctx,
     cond,

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -20,8 +20,10 @@ from unittest.mock import Mock
 
 import pytest
 
-from mplang.core.base import Mask, MPContext, MPObject, MPType, TensorInfo
 from mplang.core.dtype import FLOAT32, INT32
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPContext, MPObject
+from mplang.core.mptype import MPType, TensorInfo
 from mplang.core.trace import TraceContext, TracedFunction, TraceVar, VarNamer, trace
 from mplang.expr.ast import VariableExpr
 

--- a/tests/expr/conftest.py
+++ b/tests/expr/conftest.py
@@ -18,8 +18,9 @@ Shared fixtures for expr tests.
 
 import pytest
 
-from mplang.core.base import Mask, TensorInfo
 from mplang.core.dtype import FLOAT32, INT32, UINT64
+from mplang.core.mask import Mask
+from mplang.core.mptype import TensorInfo
 from mplang.core.pfunc import PFunction
 
 

--- a/tests/expr/test_ast.py
+++ b/tests/expr/test_ast.py
@@ -15,8 +15,9 @@
 import numpy as np
 import pytest
 
-from mplang.core.base import Mask, MPType, Rank, TensorInfo
 from mplang.core.dtype import FLOAT32, INT32, UINT64
+from mplang.core.mask import Mask
+from mplang.core.mptype import MPType, Rank, TensorInfo
 from mplang.expr import (
     AccessExpr,
     CallExpr,

--- a/tests/expr/test_printer.py
+++ b/tests/expr/test_printer.py
@@ -19,8 +19,9 @@ Tests for expression printer module.
 import numpy as np
 import pytest
 
-from mplang.core.base import Mask, Rank, TensorInfo
 from mplang.core.dtype import FLOAT32, UINT64
+from mplang.core.mask import Mask
+from mplang.core.mptype import Rank, TensorInfo
 from mplang.core.pfunc import PFunction
 from mplang.expr import (
     AccessExpr,
@@ -105,7 +106,7 @@ class TestPrinterExpressions:
     def test_variable_expr_printing(self, pmask_2p):
         """Test printing of VariableExpr."""
         printer = Printer(compact_format=False)
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         mptype = MPType.tensor(FLOAT32, (2, 2), pmask_2p)
         expr = VariableExpr("test_var", mptype)
@@ -267,7 +268,7 @@ class TestPrinterExpressions:
         printer = Printer(compact_format=False)
 
         # Create a function body that actually uses the parameters
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         x_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
         y_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
@@ -305,7 +306,7 @@ class TestPrinterComplexExpressions:
         pred = RankExpr(pmask_2p)
 
         # Create then function that actually uses the parameter 'x'
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         x_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
         x_var = VariableExpr("x", x_mptype)  # Reference the parameter
@@ -343,7 +344,7 @@ class TestPrinterComplexExpressions:
     def test_all_expr_types_printing(self, pmask_2p, pfunc_1i1o):
         """Test printing of a complex expression involving all Expr types with meaningful parameter usage."""
         printer = Printer(compact_format=False)
-        from mplang.core.base import MPType, Rank
+        from mplang.core.mptype import MPType, Rank
 
         # 1. Basic primitive expressions
         const_expr = ConstExpr(
@@ -455,7 +456,7 @@ class TestPrinterComplexExpressions:
         printer = Printer(compact_format=False)
 
         # Create condition function that uses the 'state' parameter
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         state_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
         state_var = VariableExpr("state", state_mptype)
@@ -498,7 +499,7 @@ class TestPrinterComplexExpressions:
         printer = Printer(compact_format=False)
 
         # Create function body that actually uses the parameters
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         x_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
         y_mptype = MPType.tensor(FLOAT32, (1,), pmask_2p)
@@ -641,7 +642,7 @@ class TestPrinterEdgeCases:
         printer = Printer(compact_format=False)
 
         # Create nested function definitions with meaningful parameter usage
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         inner_param_type = MPType.tensor(FLOAT32, (1,), pmask_2p)
         middle_param_type = MPType.tensor(FLOAT32, (1,), pmask_2p)
@@ -758,7 +759,7 @@ class TestPrinterMeaningfulParameterUsage:
     def test_meaningful_parameter_usage_scenarios(self, pmask_2p):
         """Test various scenarios where function parameters are meaningfully used."""
         printer = Printer(compact_format=False)
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         # Scenario 1: Parameter used in conditional predicate
         param_type = MPType.tensor(FLOAT32, (2,), pmask_2p)
@@ -797,7 +798,7 @@ class TestPrinterMeaningfulParameterUsage:
     def test_parameter_reuse_in_complex_expressions(self, pmask_2p):
         """Test parameter being used multiple times in the same function."""
         printer = Printer(compact_format=False)
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         # Create a function that uses the same parameter multiple times
         param_type = MPType.tensor(FLOAT32, (1,), pmask_2p)
@@ -823,7 +824,7 @@ class TestPrinterMeaningfulParameterUsage:
     def test_while_loop_with_meaningful_state_usage(self, pmask_2p):
         """Test while loop where state parameter is meaningfully used."""
         printer = Printer(compact_format=False)
-        from mplang.core.base import MPType
+        from mplang.core.mptype import MPType
 
         # Create a while loop that actually processes the state
         state_type = MPType.tensor(FLOAT32, (3,), pmask_2p)

--- a/tests/expr/test_utils.py
+++ b/tests/expr/test_utils.py
@@ -14,8 +14,8 @@
 
 import pytest
 
-from mplang.core.base import Mask
 from mplang.core.dtype import FLOAT32, INT32
+from mplang.core.mask import Mask
 from mplang.expr import deduce_mask, ensure_scalar, ensure_tensorlist_equal, type_equal
 
 

--- a/tests/expr/test_visitor.py
+++ b/tests/expr/test_visitor.py
@@ -14,8 +14,9 @@
 
 import pytest
 
-from mplang.core.base import Mask, TensorInfo
 from mplang.core.dtype import FLOAT32, INT32
+from mplang.core.mask import Mask
+from mplang.core.mptype import TensorInfo
 from mplang.expr import ConstExpr, Expr, ExprTransformer, Printer
 from mplang.expr.ast import RankExpr
 

--- a/tests/frontend/test_spu.py
+++ b/tests/frontend/test_spu.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 import spu.libspu as libspu
 
-from mplang.core.base import TensorInfo
+from mplang.core.mptype import TensorInfo
 from mplang.frontend.spu import SpuFE, Visibility
 
 

--- a/tests/runtime/test_simulation.py
+++ b/tests/runtime/test_simulation.py
@@ -27,9 +27,11 @@ import numpy as np
 import pytest
 
 from mplang import simp
-from mplang.core.base import Mask, MPObject, MPType, Rank
 from mplang.core.context_mgr import with_ctx
 from mplang.core.dtype import FLOAT32, INT32
+from mplang.core.mask import Mask
+from mplang.core.mpobject import MPObject
+from mplang.core.mptype import MPType, Rank
 from mplang.core.primitive import cond, constant, prank, pshfl_s, while_loop
 from mplang.core.trace import TraceContext, TraceVar, trace
 from mplang.runtime.simulation import Simulator, SimVar

--- a/tutorials/7_stdio.py
+++ b/tutorials/7_stdio.py
@@ -18,7 +18,7 @@ import numpy as np
 import mplang
 import mplang.simp as simp
 import mplang.smpc as smpc
-from mplang.core.base import TensorInfo
+from mplang.core.mptype import TensorInfo
 from mplang.frontend import builtin
 
 


### PR DESCRIPTION
…asses

- Moved MPContext and MPObject definitions from mplang.core.base to mplang.core.mpobject.
- Introduced new MPType class in mplang.core.mptype to encapsulate type information for MPObjects.
- Updated all relevant imports across the codebase to reflect the new structure.
- Ensured that the new MPType class supports tensor and relation types with appropriate attributes and methods.
- Adjusted tests and tutorials to accommodate the changes in the core module structure.