### PR TITLE
Refactor exports in dtype.py, pfunc.py, and __init__.py

### DIFF
--- a/mplang/core/dtype.py
+++ b/mplang/core/dtype.py
@@ -27,6 +27,35 @@ try:
 except ImportError:
     _JAX_AVAILABLE = False
 
+__all__ = [
+    "BINARY",
+    "BOOL",
+    "COMPLEX64",
+    "COMPLEX128",
+    "DATE",
+    "DECIMAL",
+    "FLOAT16",
+    "FLOAT32",
+    "FLOAT64",
+    "INT8",
+    "INT16",
+    "INT32",
+    "INT64",
+    "INTERVAL",
+    "JSON",
+    "STRING",
+    "TIME",
+    "TIMESTAMP",
+    "UINT8",
+    "UINT16",
+    "UINT32",
+    "UINT64",
+    "UUID",
+    "DType",
+    "from_numpy",
+    "to_numpy",
+]
+
 
 @final
 @dataclass(frozen=True)
@@ -227,34 +256,3 @@ def from_numpy(np_dtype: Any) -> DType:
 def to_numpy(dtype: DType) -> np.dtype:
     """Convert custom DType to NumPy dtype."""
     return dtype.to_numpy()
-
-
-# Export all public types and constants
-__all__ = [
-    "BINARY",
-    "BOOL",
-    "COMPLEX64",
-    "COMPLEX128",
-    "DATE",
-    "DECIMAL",
-    "FLOAT16",
-    "FLOAT32",
-    "FLOAT64",
-    "INT8",
-    "INT16",
-    "INT32",
-    "INT64",
-    "INTERVAL",
-    "JSON",
-    "STRING",
-    "TIME",
-    "TIMESTAMP",
-    "UINT8",
-    "UINT16",
-    "UINT32",
-    "UINT64",
-    "UUID",
-    "DType",
-    "from_numpy",
-    "to_numpy",
-]

--- a/mplang/core/pfunc.py
+++ b/mplang/core/pfunc.py
@@ -23,6 +23,15 @@ from typing import Any, Generic, TypeVar
 from mplang.core.mptype import TensorLike, TensorType
 from mplang.core.relation import RelationLike, RelationType
 
+__all__ = [
+    "HybridHandler",
+    "PFunction",
+    "PFunctionHandler",
+    "RelationHandler",
+    "TensorHandler",
+    "get_fn_name",
+]
+
 # Define type variables
 InputType = TypeVar("InputType", bound=TensorLike | RelationLike)
 OutputType = TypeVar("OutputType", bound=TensorLike | RelationLike)
@@ -175,14 +184,3 @@ class HybridHandler(
     PFunctionHandler[TensorLike | RelationLike, TensorLike | RelationLike]
 ):
     """Handler base class that can process mixed types."""
-
-
-# Exported public API
-__all__ = [
-    "HybridHandler",
-    "PFunction",
-    "PFunctionHandler",
-    "RelationHandler",
-    "TensorHandler",
-    "get_fn_name",
-]

--- a/mplang/expr/__init__.py
+++ b/mplang/expr/__init__.py
@@ -61,12 +61,9 @@ __all__ = [
     "ConstExpr",
     "ConvExpr",
     "EvalExpr",
-    # Built-in visitors
     "Evaluator",
-    # Core expression types
     "Expr",
     "ExprTransformer",
-    # Visitor pattern
     "ExprVisitor",
     "FuncDefExpr",
     "Printer",
@@ -77,7 +74,6 @@ __all__ = [
     "TupleExpr",
     "VariableExpr",
     "WhileExpr",
-    # Utilities
     "deduce_mask",
     "ensure_scalar",
     "ensure_tensorlist_equal",


### PR DESCRIPTION
Clean up and consolidate the `__all__` exports in multiple files for better organization and clarity.