### PR TITLE
Refactor TensorType imports to a new tensor module

### DIFF
--- a/mplang/core/mpir.py
+++ b/mplang/core/mpir.py
@@ -21,9 +21,10 @@ import spu.libspu as spu_api
 
 from mplang.core.dtype import DATE, JSON, STRING, TIME, TIMESTAMP, DType
 from mplang.core.mask import Mask
-from mplang.core.mptype import MPType, TensorType
+from mplang.core.mptype import MPType
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableType
+from mplang.core.tensor import TensorType
 from mplang.expr import Expr, ExprVisitor, FuncDefExpr
 from mplang.expr.ast import (
     AccessExpr,

--- a/mplang/core/mpobject.py
+++ b/mplang/core/mpobject.py
@@ -19,8 +19,9 @@ from typing import Any
 
 from mplang.core.dtype import DType
 from mplang.core.mask import Mask
-from mplang.core.mptype import MPType, Shape
+from mplang.core.mptype import MPType
 from mplang.core.table import TableType
+from mplang.core.tensor import Shape
 
 
 class MPContext(ABC):

--- a/mplang/core/mptype.py
+++ b/mplang/core/mptype.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -26,58 +25,10 @@ if TYPE_CHECKING:
 from mplang.core.dtype import STRING, DType
 from mplang.core.mask import Mask
 from mplang.core.table import TableLike, TableType
+from mplang.core.tensor import ScalarType, Shape, TensorLike, TensorType
 
 # basic type aliases
 Rank = int
-Shape = tuple[int, ...]
-ScalarType = int | float | bool | complex
-
-
-@runtime_checkable
-class TensorLike(Protocol):
-    """
-    Protocol for objects structurally resembling tensors from common libraries
-    (NumPy, PyTorch, JAX), focusing on dtype and shape attributes.
-    """
-
-    @property
-    def dtype(self) -> Any: ...
-
-    @property
-    def shape(self) -> Shape: ...
-
-
-@dataclass(frozen=True)
-class TensorType:
-    """A data class that describes the type information of a tensor."""
-
-    dtype: DType
-    shape: Shape
-
-    def __init__(self, dtype: DType | Any, shape: Shape):
-        # Convert dtype to DType if needed
-        if not isinstance(dtype, DType):
-            dtype = DType.from_any(dtype)
-        object.__setattr__(self, "dtype", dtype)
-        object.__setattr__(self, "shape", shape)
-
-    @classmethod
-    def from_obj(cls, obj: TensorLike | ScalarType) -> TensorType:
-        if isinstance(obj, ScalarType):
-            return cls(DType.from_python_type(type(obj)), ())
-        elif isinstance(obj, TensorLike):
-            return cls(DType.from_any(obj.dtype), obj.shape)
-        else:
-            raise TypeError(f"Unsupported type: {type(obj)}.")
-
-    def to_numpy(self) -> np.dtype:
-        """Convert to NumPy dtype for compatibility."""
-        return self.dtype.to_numpy()
-
-    def __repr__(self) -> str:
-        shape_str = "x".join(str(d) for d in self.shape)
-        dtype_name = str(self.dtype)
-        return f"Tensor<{shape_str}x{dtype_name}>" if shape_str else f"{dtype_name}"
 
 
 class MPType:

--- a/mplang/core/pfunc.py
+++ b/mplang/core/pfunc.py
@@ -20,8 +20,8 @@ from collections.abc import Sequence
 from types import MappingProxyType
 from typing import Any, Generic, TypeVar
 
-from mplang.core.mptype import TensorLike, TensorType
 from mplang.core.table import TableLike, TableType
+from mplang.core.tensor import TensorLike, TensorType
 
 __all__ = [
     "HybridHandler",

--- a/mplang/core/primitive.py
+++ b/mplang/core/primitive.py
@@ -33,10 +33,10 @@ from mplang.core.dtype import UINT64
 from mplang.core.interp import InterpContext, InterpVar, apply
 from mplang.core.mask import Mask
 from mplang.core.mpobject import MPContext, MPObject
-from mplang.core.mptype import Rank, ScalarType
+from mplang.core.mptype import Rank
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableLike, dataframe_to_table_constant
-from mplang.core.tensor import Shape, TensorLike, TensorType
+from mplang.core.tensor import ScalarType, Shape, TensorLike, TensorType
 from mplang.core.trace import TraceContext, TraceVar, trace
 from mplang.expr.ast import (
     AccessExpr,

--- a/mplang/core/primitive.py
+++ b/mplang/core/primitive.py
@@ -33,9 +33,10 @@ from mplang.core.dtype import UINT64
 from mplang.core.interp import InterpContext, InterpVar, apply
 from mplang.core.mask import Mask
 from mplang.core.mpobject import MPContext, MPObject
-from mplang.core.mptype import Rank, ScalarType, Shape, TensorLike, TensorType
+from mplang.core.mptype import Rank, ScalarType
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableLike, dataframe_to_table_constant
+from mplang.core.tensor import Shape, TensorLike, TensorType
 from mplang.core.trace import TraceContext, TraceVar, trace
 from mplang.expr.ast import (
     AccessExpr,

--- a/mplang/core/tensor.py
+++ b/mplang/core/tensor.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+
+from mplang.core.dtype import DType
+
+# basic type aliases
+Shape = tuple[int, ...]
+ScalarType = int | float | bool | complex
+
+__all__ = ["ScalarType", "Shape", "TensorLike", "TensorType"]
+
+
+@runtime_checkable
+class TensorLike(Protocol):
+    """
+    Protocol for objects structurally resembling tensors from common libraries
+    (NumPy, PyTorch, JAX), focusing on dtype and shape attributes.
+    """
+
+    @property
+    def dtype(self) -> Any: ...
+
+    @property
+    def shape(self) -> Shape: ...
+
+
+@dataclass(frozen=True)
+class TensorType:
+    """A data class that describes the type information of a tensor."""
+
+    dtype: DType
+    shape: Shape
+
+    def __init__(self, dtype: DType | Any, shape: Shape):
+        # Convert dtype to DType if needed
+        if not isinstance(dtype, DType):
+            dtype = DType.from_any(dtype)
+        object.__setattr__(self, "dtype", dtype)
+        object.__setattr__(self, "shape", shape)
+
+    @classmethod
+    def from_obj(cls, obj: TensorLike | ScalarType) -> TensorType:
+        if isinstance(obj, ScalarType):
+            return cls(DType.from_python_type(type(obj)), ())
+        elif isinstance(obj, TensorLike):
+            return cls(DType.from_any(obj.dtype), obj.shape)
+        else:
+            raise TypeError(f"Unsupported type: {type(obj)}.")
+
+    def to_numpy(self) -> np.dtype:
+        """Convert to NumPy dtype for compatibility."""
+        return self.dtype.to_numpy()
+
+    def __repr__(self) -> str:
+        shape_str = "x".join(str(d) for d in self.shape)
+        dtype_name = str(self.dtype)
+        return f"Tensor<{shape_str}x{dtype_name}>" if shape_str else f"{dtype_name}"

--- a/mplang/expr/ast.py
+++ b/mplang/expr/ast.py
@@ -28,9 +28,10 @@ from typing import TYPE_CHECKING, Any
 
 from mplang.core.dtype import UINT64
 from mplang.core.mask import Mask
-from mplang.core.mptype import MPType, Rank, TensorType
+from mplang.core.mptype import MPType, Rank
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableType
+from mplang.core.tensor import TensorType
 from mplang.expr.utils import deduce_mask
 
 if TYPE_CHECKING:

--- a/mplang/frontend/builtin.py
+++ b/mplang/frontend/builtin.py
@@ -17,8 +17,8 @@ from typing import Any
 from jax.tree_util import PyTreeDef, tree_flatten
 
 from mplang.core.mpobject import MPObject
-from mplang.core.mptype import TensorType
 from mplang.core.pfunc import PFunction
+from mplang.core.tensor import TensorType
 
 
 def identity(obj: MPObject) -> tuple[PFunction, list[MPObject], PyTreeDef]:

--- a/mplang/frontend/jax_cc.py
+++ b/mplang/frontend/jax_cc.py
@@ -22,8 +22,8 @@ import jax.numpy as jnp
 from jax.tree_util import PyTreeDef, tree_flatten
 
 from mplang.core.mpobject import MPObject
-from mplang.core.mptype import TensorType
 from mplang.core.pfunc import PFunction, get_fn_name
+from mplang.core.tensor import TensorType
 from mplang.utils.func_utils import normalize_fn
 
 # Enable 64-bit precision for JAX to match tensor types

--- a/mplang/frontend/spu.py
+++ b/mplang/frontend/spu.py
@@ -24,8 +24,8 @@ import spu.utils.frontend as spu_fe
 from jax import ShapeDtypeStruct
 from jax.tree_util import PyTreeDef, tree_flatten
 
-from mplang.core.mptype import TensorLike, TensorType
 from mplang.core.pfunc import PFunction, get_fn_name
+from mplang.core.tensor import TensorLike, TensorType
 from mplang.utils.func_utils import normalize_fn
 
 

--- a/tests/backend/test_builtin.py
+++ b/tests/backend/test_builtin.py
@@ -19,8 +19,8 @@ import numpy as np
 import pytest
 
 from mplang.backend.builtin import BuiltinHandler
-from mplang.core.mptype import TensorType
 from mplang.core.pfunc import PFunction
+from mplang.core.tensor import TensorType
 
 
 class TestBuiltinHandler:

--- a/tests/backend/test_spu.py
+++ b/tests/backend/test_spu.py
@@ -20,7 +20,7 @@ import spu.api as spu_api
 import spu.libspu as libspu
 
 from mplang.backend.spu import SpuHandler, SpuValue
-from mplang.core.mptype import TensorType
+from mplang.core.tensor import TensorType
 from mplang.frontend.spu import SpuFE
 from mplang.runtime.grpc_comm import LinkCommunicator
 

--- a/tests/backend/test_stablehlo.py
+++ b/tests/backend/test_stablehlo.py
@@ -20,8 +20,8 @@ import pytest
 from jax.tree_util import tree_flatten, tree_unflatten
 
 from mplang.backend.stablehlo import StablehloHandler
-from mplang.core.mptype import TensorType
 from mplang.core.pfunc import PFunction
+from mplang.core.tensor import TensorType
 from mplang.frontend import jax_cc
 
 # Enable 64-bit precision in JAX for testing different dtypes

--- a/tests/core/test_dtype.py
+++ b/tests/core/test_dtype.py
@@ -34,7 +34,8 @@ from mplang.core.dtype import (
 )
 from mplang.core.mask import Mask
 from mplang.core.mpir import dtype_to_proto
-from mplang.core.mptype import MPType, TensorType
+from mplang.core.mptype import MPType
+from mplang.core.tensor import TensorType
 
 try:
     import jax.numpy as jnp

--- a/tests/core/test_mpir.py
+++ b/tests/core/test_mpir.py
@@ -19,8 +19,9 @@ import pytest
 from mplang.core.dtype import DType
 from mplang.core.mask import Mask
 from mplang.core.mpir import Reader, Writer
-from mplang.core.mptype import MPType, TensorType
+from mplang.core.mptype import MPType
 from mplang.core.pfunc import PFunction
+from mplang.core.tensor import TensorType
 from mplang.expr import Expr
 from mplang.expr.ast import (
     AccessExpr,

--- a/tests/core/test_primitive.py
+++ b/tests/core/test_primitive.py
@@ -31,7 +31,7 @@ from mplang import simp
 from mplang.core.context_mgr import cur_ctx, with_ctx
 from mplang.core.dtype import FLOAT32, UINT64
 from mplang.core.mask import Mask
-from mplang.core.mptype import Rank, TensorType
+from mplang.core.mptype import Rank
 from mplang.core.primitive import (
     _switch_ctx,
     cond,
@@ -46,6 +46,7 @@ from mplang.core.primitive import (
     set_mask,
     while_loop,
 )
+from mplang.core.tensor import TensorType
 from mplang.core.trace import TraceContext, TraceVar, trace
 from mplang.expr.printer import Printer
 from mplang.frontend import jax_cc

--- a/tests/core/test_tensor.py
+++ b/tests/core/test_tensor.py
@@ -24,7 +24,7 @@ class TestTensor:
     """Test tensor-related functionality of MPType."""
 
     def test_tensor_creation(self):
-        """Test tensor MPType creation."""
+        """Test tensor creation."""
         tensor_type = MPType.tensor(FLOAT32, (3, 4))
 
         assert tensor_type.is_tensor

--- a/tests/core/test_tensor.py
+++ b/tests/core/test_tensor.py
@@ -21,7 +21,7 @@ from mplang.core.mptype import MPType
 
 
 class TestTensor:
-    """Test tensor-related functionality of MPType."""
+    """Test tensor-related functionality."""
 
     def test_tensor_creation(self):
         """Test tensor creation."""

--- a/tests/core/test_tensor.py
+++ b/tests/core/test_tensor.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from mplang.core.dtype import DATE, FLOAT32, FLOAT64, INT32, JSON, STRING
+from mplang.core.mask import Mask
+from mplang.core.mptype import MPType
+
+
+class TestTensor:
+    """Test tensor-related functionality of MPType."""
+
+    def test_tensor_creation(self):
+        """Test tensor MPType creation."""
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+
+        assert tensor_type.is_tensor
+        assert tensor_type.dtype == FLOAT32
+        assert tensor_type.shape == (3, 4)
+
+    def test_tensor_attribute_access(self):
+        """Test tensor attribute access."""
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+
+        # Should work
+        assert tensor_type.dtype == FLOAT32
+        assert tensor_type.shape == (3, 4)
+
+        # Should fail
+        with pytest.raises(
+            AttributeError, match="schema is only available for table types"
+        ):
+            _ = tensor_type.schema
+
+    def test_table_only_dtype_validation(self):
+        """Test that table-only dtypes cannot be used in tensors."""
+        # STRING type should fail in tensor
+        with pytest.raises(
+            ValueError, match="Data type 'string' is only supported in tables"
+        ):
+            MPType.tensor(STRING, (10,))
+
+        # DATE type should fail in tensor
+        with pytest.raises(
+            ValueError, match="Data type 'date' is only supported in tables"
+        ):
+            MPType.tensor(DATE, (5, 5))
+
+        # JSON type should fail in tensor
+        with pytest.raises(
+            ValueError, match="Data type 'json' is only supported in tables"
+        ):
+            MPType.tensor(JSON, (3,))
+
+    def test_tensor_with_pmask_and_attrs(self):
+        """Test tensor with pmask and attributes."""
+        tensor_type = MPType.tensor(
+            INT32, (10,), pmask=Mask.from_int(0b1101), device="GPU", precision="high"
+        )
+
+        assert tensor_type.pmask == Mask.from_int(0b1101)
+        assert tensor_type.attrs["device"] == "GPU"
+        assert tensor_type.attrs["precision"] == "high"
+
+    def test_tensor_equality_and_hashing(self):
+        """Test tensor equality and hashing."""
+        t1 = MPType.tensor(FLOAT32, (2, 3))
+        t2 = MPType.tensor(FLOAT32, (2, 3))
+        t3 = MPType.tensor(FLOAT64, (2, 3))
+
+        assert t1 == t2
+        assert t1 != t3
+        assert hash(t1) == hash(t2)
+        assert hash(t1) != hash(t3)
+
+    def test_tensor_string_representation(self):
+        """Test tensor string representation."""
+        # Test basic tensor representation
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+        tensor_str = str(tensor_type)
+        assert "f32[3, 4]" == tensor_str
+
+        # Test with pmask and attributes
+        tensor_with_attrs = MPType.tensor(
+            INT32, (10,), pmask=Mask.from_int(0b1101), device="GPU"
+        )
+        tensor_attrs_str = str(tensor_with_attrs)
+        assert "i32[10]<D>" in tensor_attrs_str
+        assert 'device="GPU"' in tensor_attrs_str
+
+    def test_to_numpy_tensor_only(self):
+        """Test to_numpy method only works for tensors."""
+        tensor_type = MPType.tensor(FLOAT32, (3, 4))
+        numpy_dtype = tensor_type.to_numpy()
+        assert str(numpy_dtype) == "float32"
+
+    def test_from_tensor_factory_method(self):
+        """Test from_tensor factory method."""
+        # Test with scalar
+        scalar_type = MPType.from_tensor(42)
+        assert scalar_type.is_tensor
+        assert scalar_type.shape == ()
+
+        # Test with numpy array
+        arr = np.array([[1, 2], [3, 4]], dtype=np.float32)
+        array_type = MPType.from_tensor(arr)
+        assert array_type.is_tensor
+        assert array_type.dtype == FLOAT32
+        assert array_type.shape == (2, 2)
+
+        # Test with list converted to numpy array
+        list_arr = np.array([1, 2, 3])
+        list_type = MPType.from_tensor(list_arr)
+        assert list_type.is_tensor
+        assert list_type.shape == (3,)

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -23,7 +23,8 @@ import pytest
 from mplang.core.dtype import FLOAT32, INT32
 from mplang.core.mask import Mask
 from mplang.core.mpobject import MPContext, MPObject
-from mplang.core.mptype import MPType, TensorType
+from mplang.core.mptype import MPType
+from mplang.core.tensor import TensorType
 from mplang.core.trace import TraceContext, TracedFunction, TraceVar, VarNamer, trace
 from mplang.expr.ast import VariableExpr
 

--- a/tests/expr/conftest.py
+++ b/tests/expr/conftest.py
@@ -20,8 +20,8 @@ import pytest
 
 from mplang.core.dtype import FLOAT32, INT32, UINT64
 from mplang.core.mask import Mask
-from mplang.core.mptype import TensorType
 from mplang.core.pfunc import PFunction
+from mplang.core.tensor import TensorType
 
 
 @pytest.fixture

--- a/tests/expr/test_ast.py
+++ b/tests/expr/test_ast.py
@@ -17,7 +17,8 @@ import pytest
 
 from mplang.core.dtype import FLOAT32, INT32, UINT64
 from mplang.core.mask import Mask
-from mplang.core.mptype import MPType, Rank, TensorType
+from mplang.core.mptype import MPType, Rank
+from mplang.core.tensor import TensorType
 from mplang.expr import (
     AccessExpr,
     CallExpr,

--- a/tests/expr/test_printer.py
+++ b/tests/expr/test_printer.py
@@ -21,8 +21,9 @@ import pytest
 
 from mplang.core.dtype import FLOAT32, UINT64
 from mplang.core.mask import Mask
-from mplang.core.mptype import Rank, TensorType
+from mplang.core.mptype import Rank
 from mplang.core.pfunc import PFunction
+from mplang.core.tensor import TensorType
 from mplang.expr import (
     AccessExpr,
     CallExpr,

--- a/tests/expr/test_visitor.py
+++ b/tests/expr/test_visitor.py
@@ -16,7 +16,7 @@ import pytest
 
 from mplang.core.dtype import FLOAT32, INT32
 from mplang.core.mask import Mask
-from mplang.core.mptype import TensorType
+from mplang.core.tensor import TensorType
 from mplang.expr import ConstExpr, Expr, ExprTransformer, Printer
 from mplang.expr.ast import RankExpr
 

--- a/tests/frontend/test_spu.py
+++ b/tests/frontend/test_spu.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 import spu.libspu as libspu
 
-from mplang.core.mptype import TensorType
+from mplang.core.tensor import TensorType
 from mplang.frontend.spu import SpuFE, Visibility
 
 

--- a/tutorials/7_stdio.py
+++ b/tutorials/7_stdio.py
@@ -18,7 +18,7 @@ import numpy as np
 import mplang
 import mplang.simp as simp
 import mplang.smpc as smpc
-from mplang.core.mptype import TensorType
+from mplang.core.tensor import TensorType
 from mplang.frontend import builtin
 
 


### PR DESCRIPTION
Move TensorType and related imports from the mptype module to a newly created tensor module for better organization and clarity.