### PR TITLE
Add frontend operation classes and CLAUDE documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MPLang (Multi-Party Programming Language) is a single-controller programming library for secure multi-party computation (MPC) and multi-device workloads. It follows the SPMD (Single Program, Multiple Data) model where one Python program orchestrates multiple parties and devices with explicit security domains.
+
+### Key Features
+- Single-controller SPMD: One program orchestrates multiple parties in lockstep
+- Explicit devices and security domains: Clear annotations for P0/P1/SPU
+- Function-level compilation (@mplang.function): Enables graph optimizations and audit
+- Pluggable frontends and backends: Supports JAX, Ibis frontends and StableHLO, SPU PPHlo IR backends
+
+## Development Commands
+
+### Installation and Setup
+```bash
+# Install uv (if not installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install from source
+uv pip install .
+
+# Editable install for development
+uv pip install -e .
+
+# Install development dependencies
+uv sync --group dev
+```
+
+### Running Tests
+```bash
+# Run all tests
+uv run pytest
+
+# Run specific test file
+uv run pytest tests/core/test_primitive.py
+
+# Run tests with coverage
+uv run pytest --cov=mplang
+
+# Run tests in parallel
+uv run pytest -n auto
+```
+
+### Code Quality and Type Checking
+```bash
+# Run linter
+uv run ruff check .
+
+# Fix lint issues automatically
+uv run ruff check . --fix
+
+# Format code
+uv run ruff format .
+
+# Run type checker
+uv run mypy mplang/
+```
+
+### Running Examples
+```bash
+# Run tutorials
+uv run tutorials/0_basic.py
+
+# Run other examples
+uv run tutorials/1_condition.py
+uv run tutorials/2_whileloop.py
+```
+
+## Architecture Overview
+
+### Core Components
+
+1. **Core System (`mplang/core/`)**
+   - `mpobject.py`: Base MPObject and MPContext classes
+   - `primitive.py`: Fundamental primitive operations with @primitive decorator
+   - `trace.py`: TraceContext and TraceVar for lazy evaluation and expression building
+   - `interp.py`: InterpContext and InterpVar for runtime interpretation
+
+2. **Expression System (`mplang/expr/`)**
+   - AST representation of computation graphs
+   - Expression evaluation and transformation
+
+3. **Runtime System (`mplang/runtime/`)**
+   - `simulation.py`: Simulator for local testing with multiple threads
+   - Communication layers for multi-party execution
+
+4. **Frontends and Backends**
+   - Frontends (`mplang/frontend/`): JAX, Ibis integration
+   - Backends (`mplang/backend/`): SPU, StableHLO, SQL/DuckDB implementations
+
+5. **Devices (`mplang/device.py`)**
+   - Device-oriented programming interface
+   - Automatic data transformation between devices
+
+### Key Design Patterns
+
+1. **Context Management**: Uses context managers for switching between trace and interpretation contexts
+2. **Lazy Evaluation**: Computations are traced into expressions rather than executed immediately
+3. **SPMD Model**: Single Program, Multiple Data execution model for multi-party coordination
+4. **Trace and Interpret**: Functions can be traced to build computation graphs or interpreted for immediate execution
+
+### Important APIs
+
+- `@mplang.function`: Decorator for tracing functions into computation graphs
+- `mplang.compile()`: Compile functions into traced representations
+- `mplang.evaluate()`: Execute traced functions in interpreter contexts
+- `mplang.fetch()`: Retrieve results from interpreter contexts
+- `mplang.Simulator()`: Create simulation environments for testing
+
+### Testing Approach
+
+Tests are organized by module and use pytest. Key patterns:
+- Use TraceContext for testing primitive operations
+- Trace functions to create TracedFunction objects
+- Verify expression output using Printer for IR inspection
+- Test both compile-time and runtime behavior

--- a/mplang/frontend/__init__.py
+++ b/mplang/frontend/__init__.py
@@ -18,3 +18,9 @@ Frontend module for mplang.
 This module contains compilers that transform high-level functions into
 portable, serializable intermediate representations.
 """
+
+from mplang.frontend import builtin as builtin
+from mplang.frontend import ibis_cc as ibis_cc
+from mplang.frontend import jax_cc as jax_cc
+from mplang.frontend import phe as phe
+from mplang.frontend.base import FEOp as FEOp

--- a/mplang/frontend/__init__.py
+++ b/mplang/frontend/__init__.py
@@ -24,3 +24,5 @@ from mplang.frontend import ibis_cc as ibis_cc
 from mplang.frontend import jax_cc as jax_cc
 from mplang.frontend import phe as phe
 from mplang.frontend.base import FEOp as FEOp
+from mplang.frontend.ibis_cc import ibis_compile as ibis_compile
+from mplang.frontend.jax_cc import jax_compile as jax_compile

--- a/mplang/frontend/base.py
+++ b/mplang/frontend/base.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from jax.tree_util import PyTreeDef
+
+from mplang.core.mpobject import MPObject
+from mplang.core.pfunc import PFunction
+
+
+class FEOp(ABC):
+    """Base class for all frontend operations.
+
+    This class provides a common interface for all frontend operations
+    that can be compiled and executed by the mplang system.
+    """
+
+    @abstractmethod
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Compile the function with given arguments.
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: The compiled function,
+            input arguments, and output tree definition.
+        """

--- a/mplang/frontend/builtin.py
+++ b/mplang/frontend/builtin.py
@@ -21,171 +21,213 @@ from mplang.core.mpobject import MPObject
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableLike, TableType
 from mplang.core.tensor import ScalarType, Shape, TensorLike, TensorType
+from mplang.frontend.base import FEOp
 from mplang.utils import table_utils
 
 
-def identity(obj: MPObject) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Create an identity operation for an MPObject.
+class Identity(FEOp):
+    """Identity function class."""
 
-    Args:
-        obj: The MPObject to create identity operation for
+    def __call__(self, obj: MPObject) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Create an identity operation for an MPObject.
 
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for identity, args list with obj, output tree definition
-    """
-    obj_ty = TensorType.from_obj(obj)
-    pfunc = PFunction(
-        fn_type="builtin.identity",
-        ins_info=(obj_ty,),
-        outs_info=(obj_ty,),
-    )
-    _, treedef = tree_flatten(obj_ty)
-    return pfunc, [obj], treedef
+        Args:
+            obj: The MPObject to create identity operation for
 
-
-def read(
-    path: str, ty: TensorType, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """
-    Read data from a file.
-
-    Args:
-        path: The file path to read from
-        ty: The tensor type information for the data
-        **kwargs: Additional attributes for reading
-
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for reading, empty args list, output tree definition
-    """
-    pfunc = PFunction(
-        fn_type="builtin.read",
-        ins_info=(),
-        outs_info=(ty,),
-        path=path,
-        **kwargs,
-    )
-    _, treedef = tree_flatten(ty)
-    return pfunc, [], treedef
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for identity, args list with obj, output tree definition
+        """
+        obj_ty = TensorType.from_obj(obj)
+        pfunc = PFunction(
+            fn_type="builtin.identity",
+            ins_info=(obj_ty,),
+            outs_info=(obj_ty,),
+        )
+        _, treedef = tree_flatten(obj_ty)
+        return pfunc, [obj], treedef
 
 
-def write(obj: MPObject, path: str) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """
-    Write data to a file.
-
-    Args:
-        obj: The MPObject to write
-        path: The file path to write to
-
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for writing, args list with obj, output tree definition
-
-    Raises:
-        ValueError: If obj is not provided
-    """
-    if obj is None:
-        raise ValueError("builtin.write requires an object to write")
-
-    obj_ty = TensorType.from_obj(obj)
-    pfunc = PFunction(
-        fn_type="builtin.write",
-        ins_info=(obj_ty,),
-        outs_info=(obj_ty,),
-        path=path,
-    )
-    _, treedef = tree_flatten(obj_ty)
-    return pfunc, [obj], treedef
+identity = Identity()
 
 
-def constant(
-    data: TensorLike | ScalarType | TableLike,
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Create a constant tensor or table from data.
+class Read(FEOp):
+    """Read function class."""
 
-    Args:
-        data: The constant data to embed. Can be:
-              - A scalar value (int, float, bool)
-              - A numpy array or other tensor-like object
-              - A pandas DataFrame or other table-like object
-              - Any object that can be converted to tensor
+    def __call__(
+        self, path: str, ty: TensorType, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """
+        Read data from a file.
 
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for constant, empty args list, output tree definition
-    """
-    import numpy as np
+        Args:
+            path: The file path to read from
+            ty: The tensor type information for the data
+            **kwargs: Additional attributes for reading
 
-    data_bytes: bytes
-    out_type: TableType | TensorType
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for reading, empty args list, output tree definition
+        """
+        pfunc = PFunction(
+            fn_type="builtin.read",
+            ins_info=(),
+            outs_info=(ty,),
+            path=path,
+            **kwargs,
+        )
+        _, treedef = tree_flatten(ty)
+        return pfunc, [], treedef
 
-    if isinstance(data, TableLike):
-        data_bytes = table_utils.dataframe_to_csv(data)
-        data_format = "bytes[csv]"
-        out_type = TableType.from_tablelike(data)
-    elif isinstance(data, ScalarType):
-        out_type = TensorType.from_obj(data)
-        # For scalars, convert to numpy array then to bytes
-        np_data = np.array(data)
-        data_bytes = np_data.tobytes()
-        data_format = "bytes[numpy]"
-    else:
-        if hasattr(data, "tobytes"):
-            # For numpy arrays and other TensorLike objects with tobytes method
+
+read = Read()
+
+
+class Write(FEOp):
+    """Write function class."""
+
+    def __call__(
+        self, obj: MPObject, path: str
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """
+        Write data to a file.
+
+        Args:
+            obj: The MPObject to write
+            path: The file path to write to
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for writing, args list with obj, output tree definition
+
+        Raises:
+            ValueError: If obj is not provided
+        """
+        if obj is None:
+            raise ValueError("builtin.write requires an object to write")
+
+        obj_ty = TensorType.from_obj(obj)
+        pfunc = PFunction(
+            fn_type="builtin.write",
+            ins_info=(obj_ty,),
+            outs_info=(obj_ty,),
+            path=path,
+        )
+        _, treedef = tree_flatten(obj_ty)
+        return pfunc, [obj], treedef
+
+
+write = Write()
+
+
+class Constant(FEOp):
+    """Constant function class."""
+
+    def __call__(
+        self,
+        data: TensorLike | ScalarType | TableLike,
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Create a constant tensor or table from data.
+
+        Args:
+            data: The constant data to embed. Can be:
+                  - A scalar value (int, float, bool)
+                  - A numpy array or other tensor-like object
+                  - A pandas DataFrame or other table-like object
+                  - Any object that can be converted to tensor
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for constant, empty args list, output tree definition
+        """
+        import numpy as np
+
+        data_bytes: bytes
+        out_type: TableType | TensorType
+
+        if isinstance(data, TableLike):
+            data_bytes = table_utils.dataframe_to_csv(data)
+            data_format = "bytes[csv]"
+            out_type = TableType.from_tablelike(data)
+        elif isinstance(data, ScalarType):
             out_type = TensorType.from_obj(data)
-            data_bytes = data.tobytes()  # type: ignore
-        else:
-            # For other TensorLike objects, convert to numpy first
+            # For scalars, convert to numpy array then to bytes
             np_data = np.array(data)
-            out_type = TensorType.from_obj(np_data)
             data_bytes = np_data.tobytes()
-        data_format = "bytes[numpy]"
+            data_format = "bytes[numpy]"
+        else:
+            if hasattr(data, "tobytes"):
+                # For numpy arrays and other TensorLike objects with tobytes method
+                out_type = TensorType.from_obj(data)
+                data_bytes = data.tobytes()  # type: ignore
+            else:
+                # For other TensorLike objects, convert to numpy first
+                np_data = np.array(data)
+                out_type = TensorType.from_obj(np_data)
+                data_bytes = np_data.tobytes()
+            data_format = "bytes[numpy]"
 
-    # Store tensor metadata as simple attributes
-    pfunc = PFunction(
-        fn_type="builtin.constant",
-        ins_info=(),
-        outs_info=(out_type,),
-        data_bytes=data_bytes,
-        data_format=data_format,
-    )
-    _, treedef = tree_flatten(out_type)
-    return pfunc, [], treedef
-
-
-def rank() -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Multi-party get the rank (party identifier) of each party.
-
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for rank, empty args list, output tree definition
-    """
-    # Return a scalar UINT64 tensor for rank
-    tensor_type = TensorType(UINT64, ())
-
-    pfunc = PFunction(
-        fn_type="builtin.rank",
-        ins_info=(),
-        outs_info=(tensor_type,),
-    )
-    _, treedef = tree_flatten(tensor_type)
-    return pfunc, [], treedef
+        # Store tensor metadata as simple attributes
+        pfunc = PFunction(
+            fn_type="builtin.constant",
+            ins_info=(),
+            outs_info=(out_type,),
+            data_bytes=data_bytes,
+            data_format=data_format,
+        )
+        _, treedef = tree_flatten(out_type)
+        return pfunc, [], treedef
 
 
-def prand(shape: Shape = ()) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Multi-party generate a private random (uint64) tensor with the given shape.
+constant = Constant()
 
-    Args:
-        shape: The shape of the random tensor to generate.
-               Must be a tuple of positive integers. Defaults to () for scalar.
 
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for prand, empty args list, output tree definition
-    """
-    # For now, only UINT64 is supported
-    tensor_type = TensorType(UINT64, shape)
+class Rank(FEOp):
+    """Rank function class."""
 
-    pfunc = PFunction(
-        fn_type="builtin.prand",
-        ins_info=(),
-        outs_info=(tensor_type,),
-        shape=shape,
-    )
-    _, treedef = tree_flatten(tensor_type)
-    return pfunc, [], treedef
+    def __call__(self) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Multi-party get the rank (party identifier) of each party.
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for rank, empty args list, output tree definition
+        """
+        # Return a scalar UINT64 tensor for rank
+        tensor_type = TensorType(UINT64, ())
+
+        pfunc = PFunction(
+            fn_type="builtin.rank",
+            ins_info=(),
+            outs_info=(tensor_type,),
+        )
+        _, treedef = tree_flatten(tensor_type)
+        return pfunc, [], treedef
+
+
+rank = Rank()
+
+
+class PRand(FEOp):
+    """PRand function class."""
+
+    def __call__(
+        self, shape: Shape = ()
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Multi-party generate a private random (uint64) tensor with the given shape.
+
+        Args:
+            shape: The shape of the random tensor to generate.
+                   Must be a tuple of positive integers. Defaults to () for scalar.
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for prand, empty args list, output tree definition
+        """
+        # For now, only UINT64 is supported
+        tensor_type = TensorType(UINT64, shape)
+
+        pfunc = PFunction(
+            fn_type="builtin.prand",
+            ins_info=(),
+            outs_info=(tensor_type,),
+            shape=shape,
+        )
+        _, treedef = tree_flatten(tensor_type)
+        return pfunc, [], treedef
+
+
+prand = PRand()

--- a/mplang/frontend/ibis_cc.py
+++ b/mplang/frontend/ibis_cc.py
@@ -25,6 +25,7 @@ from mplang.core import dtype
 from mplang.core.mpobject import MPObject
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableType
+from mplang.frontend.base import FEOp
 from mplang.utils.func_utils import normalize_fn
 
 
@@ -68,38 +69,6 @@ def ibis2sql(
     return pfn
 
 
-def ibis_compile(
-    func: Callable, *args: Any, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], Any]:
-    """
-    IBIS compilation helper function.
-    The func signature must like def foo(t0:ibis.Table, t1:ibis.Table)->ibis.Table
-    """
-
-    def is_variable(arg: Any) -> bool:
-        return isinstance(arg, MPObject)
-
-    normalized_fn, in_vars = normalize_fn(func, args, kwargs, is_variable)
-
-    in_args, in_schemas, in_names = [], [], []
-    idx = 0
-    for arg in in_vars:
-        columns = [(p[0], p[1].to_numpy()) for p in arg.schema.columns]
-        schema = ibis.schema(columns)
-        name = f"table{idx}"
-        table = ibis.table(schema=schema, name=name)
-        in_args.append(table)
-        in_schemas.append(schema)
-        in_names.append(name)
-        idx += 1
-
-    result = normalized_fn(in_args)
-    assert isinstance(result, ibis.Table)
-    pfunc = ibis2sql(result, in_schemas, in_names, func.__name__)
-    _, treedef = jax.tree.flatten(result)
-    return pfunc, in_vars, treedef
-
-
 def is_ibis_function(func: Callable) -> bool:
     """
     Verify whether a function is an ibis function.
@@ -120,3 +89,47 @@ def is_ibis_function(func: Callable) -> bool:
             return True
 
     return False
+
+
+class IbisCompiler(FEOp):
+    """Ibis compiler frontend operation."""
+
+    def __call__(
+        self, func: Callable, *args: Any, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], Any]:
+        """Compile an Ibis function to SQL format.
+
+        Args:
+            func: The Ibis function to compile
+            *args: Positional arguments to the function
+            **kwargs: Keyword arguments to the function
+
+        Returns:
+            tuple[PFunction, list[MPObject], Any]: The compiled PFunction, input variables, and output tree
+        """
+
+        def is_variable(arg: Any) -> bool:
+            return isinstance(arg, MPObject)
+
+        normalized_fn, in_vars = normalize_fn(func, args, kwargs, is_variable)
+
+        in_args, in_schemas, in_names = [], [], []
+        idx = 0
+        for arg in in_vars:
+            columns = [(p[0], p[1].to_numpy()) for p in arg.schema.columns]
+            schema = ibis.schema(columns)
+            name = f"table{idx}"
+            table = ibis.table(schema=schema, name=name)
+            in_args.append(table)
+            in_schemas.append(schema)
+            in_names.append(name)
+            idx += 1
+
+        result = normalized_fn(in_args)
+        assert isinstance(result, ibis.Table)
+        pfunc = ibis2sql(result, in_schemas, in_names, func.__name__)
+        _, treedef = jax.tree.flatten(result)
+        return pfunc, in_vars, treedef
+
+
+ibis_compile = IbisCompiler()

--- a/mplang/frontend/jax_cc.py
+++ b/mplang/frontend/jax_cc.py
@@ -24,6 +24,7 @@ from jax.tree_util import PyTreeDef, tree_flatten
 from mplang.core.mpobject import MPObject
 from mplang.core.pfunc import PFunction, get_fn_name
 from mplang.core.tensor import TensorType
+from mplang.frontend.base import FEOp
 from mplang.utils.func_utils import normalize_fn
 
 # Enable 64-bit precision for JAX to match tensor types
@@ -116,27 +117,33 @@ def jax2stablehlo(
     return pfn, in_vars, out_tree
 
 
-def jax_compile(
-    func: Callable, *args: Any, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], Any]:
-    """
-    JAX compilation helper function.
+class JaxCompiler(FEOp):
+    """JAX compiler frontend operation."""
 
-    Compiles a JAX function to StableHLO format and returns the PFunction
-    along with variable arguments for evaluation.
+    def __call__(
+        self, func: Callable, *args: Any, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], Any]:
+        """
+        JAX compilation helper function.
 
-    Args:
-        func: The JAX function to compile
-        *args: Positional arguments to the function
-        **kwargs: Keyword arguments to the function
+        Compiles a JAX function to StableHLO format and returns the PFunction
+        along with variable arguments for evaluation.
 
-    Returns:
-        tuple[PFunction, list[MPObject], Any]: The compiled PFunction, input variables, and output tree
-    """
+        Args:
+            func: The JAX function to compile
+            *args: Positional arguments to the function
+            **kwargs: Keyword arguments to the function
 
-    def is_variable(arg: Any) -> bool:
-        return isinstance(arg, MPObject)
+        Returns:
+            tuple[PFunction, list[MPObject], Any]: The compiled PFunction, input variables, and output tree
+        """
 
-    pfunc, in_vars, out_tree = jax2stablehlo(is_variable, func, *args, **kwargs)
+        def is_variable(arg: Any) -> bool:
+            return isinstance(arg, MPObject)
 
-    return pfunc, in_vars, out_tree
+        pfunc, in_vars, out_tree = jax2stablehlo(is_variable, func, *args, **kwargs)
+
+        return pfunc, in_vars, out_tree
+
+
+jax_compile = JaxCompiler()

--- a/mplang/frontend/phe.py
+++ b/mplang/frontend/phe.py
@@ -22,182 +22,214 @@ from mplang.core.dtype import COMPLEX128
 from mplang.core.mpobject import MPObject
 from mplang.core.mptype import TensorType
 from mplang.core.pfunc import PFunction
+from mplang.frontend.base import FEOp
 
 
-def keygen(
-    scheme: str = "paillier",
-    key_size: int = 2048,
-    **kwargs: Any,
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Generate a PHE key pair.
+class Keygen(FEOp):
+    """Keygen function class."""
 
-    Args:
-        scheme: The PHE scheme to use ("paillier" or "elgamal")
-        key_size: Size of the key in bits
-        **kwargs: Additional scheme-specific parameters
+    def __call__(
+        self,
+        scheme: str = "paillier",
+        key_size: int = 2048,
+        **kwargs: Any,
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Generate a PHE key pair.
 
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]:
-        Returns (public_key, private_key) as two separate outputs.
-    """
-    # For keys, dtype is meaningless as they shouldn't be used for computation,
-    # so we choose a relatively uncommon dtype to satisfy the type system
-    public_key_ty = TensorType(COMPLEX128, (1,))
-    private_key_ty = TensorType(COMPLEX128, (1,))
+        Args:
+            scheme: The PHE scheme to use ("paillier" or "elgamal")
+            key_size: Size of the key in bits
+            **kwargs: Additional scheme-specific parameters
 
-    pfunc = PFunction(
-        fn_type="phe.keygen",
-        ins_info=(),
-        outs_info=(public_key_ty, private_key_ty),
-        scheme=scheme,
-        key_size=key_size,
-        **kwargs,
-    )
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]:
+            Returns (public_key, private_key) as two separate outputs.
+        """
+        # For keys, dtype is meaningless as they shouldn't be used for computation,
+        # so we choose a relatively uncommon dtype to satisfy the type system
+        public_key_ty = TensorType(COMPLEX128, (1,))
+        private_key_ty = TensorType(COMPLEX128, (1,))
 
-    _, treedef = tree_flatten((public_key_ty, private_key_ty))
-    return pfunc, [], treedef
-
-
-def encrypt(
-    plaintext: MPObject, public_key: MPObject, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Encrypt plaintext using PHE public key.
-
-    Args:
-        plaintext: The plaintext tensor to encrypt
-        public_key: The PHE public key
-        **kwargs: Additional encryption parameters
-
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]:
-    """
-    plaintext_ty = TensorType.from_obj(plaintext)
-    key_ty = TensorType.from_obj(public_key)
-
-    # Ciphertext has the same semantic type as plaintext (float tensor remains float)
-    # but the storage type is backend-dependent
-    ciphertext_ty = plaintext_ty
-
-    pfunc = PFunction(
-        fn_type="phe.encrypt",
-        ins_info=(plaintext_ty, key_ty),
-        outs_info=(ciphertext_ty,),
-        **kwargs,
-    )
-
-    _, treedef = tree_flatten(ciphertext_ty)
-    return pfunc, [plaintext, public_key], treedef
-
-
-def add(
-    operand1: MPObject, operand2: MPObject, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Add two PHE operands (can be plaintext or ciphertext).
-
-    Args:
-        operand1: First operand (plaintext or ciphertext)
-        operand2: Second operand (plaintext or ciphertext)
-        **kwargs: Additional operation parameters
-
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for addition, args list, output tree definition
-
-    Note:
-        MPObject only represents their semantic type. The actual operands can be:
-        - plaintext + plaintext
-        - plaintext + ciphertext
-        - ciphertext + plaintext
-        - ciphertext + ciphertext
-    """
-    op1_ty = TensorType.from_obj(operand1)
-    op2_ty = TensorType.from_obj(operand2)
-
-    # Result has the same semantic type as inputs
-    result_ty = op1_ty
-
-    pfunc = PFunction(
-        fn_type="phe.add",
-        ins_info=(op1_ty, op2_ty),
-        outs_info=(result_ty,),
-        **kwargs,
-    )
-    _, treedef = tree_flatten(result_ty)
-    return pfunc, [operand1, operand2], treedef
-
-
-def mul(
-    ciphertext: MPObject, plaintext: MPObject, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Multiply a PHE ciphertext with a plaintext value.
-
-    This operation supports multiplication of a ciphertext with a plaintext
-    in Paillier encryption scheme, which is homomorphic for multiplication
-    with plaintext values.
-
-    Note: This operation does not support floating-point x floating-point multiplication
-    due to truncation requirements in the underlying Paillier implementation. However,
-    it does support mixed-type operations like floating-point x integer.
-
-    Args:
-        ciphertext: The ciphertext to multiply
-        plaintext: The plaintext multiplier
-        **kwargs: Additional operation parameters
-
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for multiplication, args list, output tree definition
-
-    Raises:
-        ValueError: If attempting to multiply two floating-point numbers
-    """
-    ct_ty = TensorType.from_obj(ciphertext)
-    pt_ty = TensorType.from_obj(plaintext)
-
-    # Check if both operands are floating-point numbers
-    # PHE multiplication cannot handle float x float due to truncation requirements
-    # but can handle float x int or int x float
-    if ct_ty.dtype.is_floating and pt_ty.dtype.is_floating:
-        raise ValueError(
-            "PHE multiplication does not support float x float operations due to truncation requirements. "
-            "Consider using mixed types (float x int) or integer types instead."
+        pfunc = PFunction(
+            fn_type="phe.keygen",
+            ins_info=(),
+            outs_info=(public_key_ty, private_key_ty),
+            scheme=scheme,
+            key_size=key_size,
+            **kwargs,
         )
 
-    # Result has the same semantic type as the ciphertext
-    result_ty = ct_ty
-
-    pfunc = PFunction(
-        fn_type="phe.mul",
-        ins_info=(ct_ty, pt_ty),
-        outs_info=(result_ty,),
-        **kwargs,
-    )
-    _, treedef = tree_flatten(result_ty)
-    return pfunc, [ciphertext, plaintext], treedef
+        _, treedef = tree_flatten((public_key_ty, private_key_ty))
+        return pfunc, [], treedef
 
 
-def decrypt(
-    ciphertext: MPObject, private_key: MPObject, **kwargs: Any
-) -> tuple[PFunction, list[MPObject], PyTreeDef]:
-    """Decrypt ciphertext using PHE private key.
+keygen = Keygen()
 
-    Args:
-        ciphertext: The ciphertext to decrypt
-        private_key: The PHE private key
-        **kwargs: Additional decryption parameters
 
-    Returns:
-        tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for decryption, args list, output tree definition
-    """
-    ciphertext_ty = TensorType.from_obj(ciphertext)
-    key_ty = TensorType.from_obj(private_key)
+class Encrypt(FEOp):
+    """Encrypt function class."""
 
-    # Plaintext has the same semantic type as ciphertext, but is no longer encrypted
-    plaintext_ty = ciphertext_ty
+    def __call__(
+        self, plaintext: MPObject, public_key: MPObject, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Encrypt plaintext using PHE public key.
 
-    pfunc = PFunction(
-        fn_type="phe.decrypt",
-        ins_info=(ciphertext_ty, key_ty),
-        outs_info=(plaintext_ty,),
-        **kwargs,
-    )
-    _, treedef = tree_flatten(plaintext_ty)
-    return pfunc, [ciphertext, private_key], treedef
+        Args:
+            plaintext: The plaintext tensor to encrypt
+            public_key: The PHE public key
+            **kwargs: Additional encryption parameters
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]:
+        """
+        plaintext_ty = TensorType.from_obj(plaintext)
+        key_ty = TensorType.from_obj(public_key)
+
+        # Ciphertext has the same semantic type as plaintext (float tensor remains float)
+        # but the storage type is backend-dependent
+        ciphertext_ty = plaintext_ty
+
+        pfunc = PFunction(
+            fn_type="phe.encrypt",
+            ins_info=(plaintext_ty, key_ty),
+            outs_info=(ciphertext_ty,),
+            **kwargs,
+        )
+
+        _, treedef = tree_flatten(ciphertext_ty)
+        return pfunc, [plaintext, public_key], treedef
+
+
+encrypt = Encrypt()
+
+
+class Add(FEOp):
+    """Add function class."""
+
+    def __call__(
+        self, operand1: MPObject, operand2: MPObject, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Add two PHE operands (can be plaintext or ciphertext).
+
+        Args:
+            operand1: First operand (plaintext or ciphertext)
+            operand2: Second operand (plaintext or ciphertext)
+            **kwargs: Additional operation parameters
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for addition, args list, output tree definition
+
+        Note:
+            MPObject only represents their semantic type. The actual operands can be:
+            - plaintext + plaintext
+            - plaintext + ciphertext
+            - ciphertext + plaintext
+            - ciphertext + ciphertext
+        """
+        op1_ty = TensorType.from_obj(operand1)
+        op2_ty = TensorType.from_obj(operand2)
+
+        # Result has the same semantic type as inputs
+        result_ty = op1_ty
+
+        pfunc = PFunction(
+            fn_type="phe.add",
+            ins_info=(op1_ty, op2_ty),
+            outs_info=(result_ty,),
+            **kwargs,
+        )
+        _, treedef = tree_flatten(result_ty)
+        return pfunc, [operand1, operand2], treedef
+
+
+add = Add()
+
+
+class Mul(FEOp):
+    """Mul function class."""
+
+    def __call__(
+        self, ciphertext: MPObject, plaintext: MPObject, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Multiply a PHE ciphertext with a plaintext value.
+
+        This operation supports multiplication of a ciphertext with a plaintext
+        in Paillier encryption scheme, which is homomorphic for multiplication
+        with plaintext values.
+
+        Note: This operation does not support floating-point x floating-point multiplication
+        due to truncation requirements in the underlying Paillier implementation. However,
+        it does support mixed-type operations like floating-point x integer.
+
+        Args:
+            ciphertext: The ciphertext to multiply
+            plaintext: The plaintext multiplier
+            **kwargs: Additional operation parameters
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for multiplication, args list, output tree definition
+
+        Raises:
+            ValueError: If attempting to multiply two floating-point numbers
+        """
+        ct_ty = TensorType.from_obj(ciphertext)
+        pt_ty = TensorType.from_obj(plaintext)
+
+        # Check if both operands are floating-point numbers
+        # PHE multiplication cannot handle float x float due to truncation requirements
+        # but can handle float x int or int x float
+        if ct_ty.dtype.is_floating and pt_ty.dtype.is_floating:
+            raise ValueError(
+                "PHE multiplication does not support float x float operations due to truncation requirements. "
+                "Consider using mixed types (float x int) or integer types instead."
+            )
+
+        # Result has the same semantic type as the ciphertext
+        result_ty = ct_ty
+
+        pfunc = PFunction(
+            fn_type="phe.mul",
+            ins_info=(ct_ty, pt_ty),
+            outs_info=(result_ty,),
+            **kwargs,
+        )
+        _, treedef = tree_flatten(result_ty)
+        return pfunc, [ciphertext, plaintext], treedef
+
+
+mul = Mul()
+
+
+class Decrypt(FEOp):
+    """Decrypt function class."""
+
+    def __call__(
+        self, ciphertext: MPObject, private_key: MPObject, **kwargs: Any
+    ) -> tuple[PFunction, list[MPObject], PyTreeDef]:
+        """Decrypt ciphertext using PHE private key.
+
+        Args:
+            ciphertext: The ciphertext to decrypt
+            private_key: The PHE private key
+            **kwargs: Additional decryption parameters
+
+        Returns:
+            tuple[PFunction, list[MPObject], PyTreeDef]: PFunction for decryption, args list, output tree definition
+        """
+        ciphertext_ty = TensorType.from_obj(ciphertext)
+        key_ty = TensorType.from_obj(private_key)
+
+        # Plaintext has the same semantic type as ciphertext, but is no longer encrypted
+        plaintext_ty = ciphertext_ty
+
+        pfunc = PFunction(
+            fn_type="phe.decrypt",
+            ins_info=(ciphertext_ty, key_ty),
+            outs_info=(plaintext_ty,),
+            **kwargs,
+        )
+        _, treedef = tree_flatten(plaintext_ty)
+        return pfunc, [ciphertext, private_key], treedef
+
+
+decrypt = Decrypt()

--- a/mplang/simp.py
+++ b/mplang/simp.py
@@ -105,12 +105,10 @@ def run_impl(
         pfunc, eval_args, out_tree = func(*args, **kwargs)
     else:
         if ibis_cc.is_ibis_function(func):
-            fe_func = partial(ibis_cc.ibis_compile, func)
-            pfunc, eval_args, out_tree = fe_func(*args, **kwargs)
+            pfunc, eval_args, out_tree = ibis_cc.ibis_compile(func, *args, **kwargs)
         else:
             # unknown python callable, treat it as jax function
-            fe_func = partial(jax_cc.jax_compile, func)
-            pfunc, eval_args, out_tree = fe_func(*args, **kwargs)
+            pfunc, eval_args, out_tree = jax_cc.jax_compile(func, *args, **kwargs)
     results = peval(pfunc, eval_args, pmask)
     return out_tree.unflatten(results)
 

--- a/mplang/simp.py
+++ b/mplang/simp.py
@@ -23,7 +23,8 @@ from mplang.core.mask import Mask
 from mplang.core.mpobject import MPObject
 from mplang.core.mptype import Rank, ScalarType, Shape, TensorLike
 from mplang.core.pfunc import PFunction
-from mplang.frontend import builtin, ibis_cc, jax_cc, phe
+from mplang.frontend import ibis_cc, jax_cc
+from mplang.frontend.base import FEOp
 
 
 def prank() -> MPObject:
@@ -100,28 +101,16 @@ def run_impl(
         >>> stats = run_impl(compute_statistics, dataset)
     """
 
-    # TODO(jint): figure out a better way to manage function dispatch
-    FUNC_WHITE_LIST = {
-        builtin.identity,
-        builtin.read,
-        builtin.write,
-        phe.keygen,
-        phe.encrypt,
-        phe.decrypt,
-        phe.add,
-        phe.mul,
-    }
-
-    if func in FUNC_WHITE_LIST:
-        fe_func = func
+    if isinstance(func, FEOp):
+        pfunc, eval_args, out_tree = func(*args, **kwargs)
     else:
         if ibis_cc.is_ibis_function(func):
             fe_func = partial(ibis_cc.ibis_compile, func)
+            pfunc, eval_args, out_tree = fe_func(*args, **kwargs)
         else:
             # unknown python callable, treat it as jax function
             fe_func = partial(jax_cc.jax_compile, func)
-
-    pfunc, eval_args, out_tree = fe_func(*args, **kwargs)
+            pfunc, eval_args, out_tree = fe_func(*args, **kwargs)
     results = peval(pfunc, eval_args, pmask)
     return out_tree.unflatten(results)
 


### PR DESCRIPTION
Introduce `FEOp` as a base class for frontend operations, enhancing extensibility without modification. Implement specific compilers for JAX and Ibis as subclasses of `FEOp`. Add CLAUDE.md to provide guidance for developers working with the MPLang project.