### PR TITLE
Refactor dataset loading and update example dependencies

### DIFF
--- a/mplang/runtime/driver.py
+++ b/mplang/runtime/driver.py
@@ -105,6 +105,15 @@ class Driver(InterpContext):
         if trace_ranks is None:
             trace_ranks = []
 
+        def ensure_http_schema(addr):
+            return (
+                addr if addr.startswith(("http://", "https://")) else f"http://{addr}"
+            )
+
+        node_addrs = {
+            node_id: ensure_http_schema(addr) for node_id, addr in node_addrs.items()
+        }
+
         self.world_size = len(node_addrs)
         self.node_addrs = node_addrs
         self.timeout = timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,7 @@ dev = [
     "httpx>=0.27.0",
 ]
 
-examples = [
-    "numpy==1.26.4",
-    "tensorflow-datasets==4.9.9",
-    "tensorflow==2.18.1",
-    "scikit-learn==1.7.1",
-    "keras==3.11.1",
-]
+examples = ["scikit-learn", "keras"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["mplang"]

--- a/tutorials/4_simulation.py
+++ b/tutorials/4_simulation.py
@@ -151,7 +151,7 @@ def device_eager(ectx):
             },
         },
         "P0": {"type": "PPU", "node_ids": ["node:0"]},
-        "P1": {"type": "PPU", "node_ids": ["node:1"]},
+        "P1": {"type": "PPU", "node_ids": ["node:3"]},
     }
 
     # Initialize device configuration
@@ -222,16 +222,8 @@ def cmd_main(main_func) -> None:
         )
         main_func(simulator)
     elif args.command == "run":
-        # Convert node addresses to HTTP URLs for Driver
-        http_nodes_def = {}
-        for node_id, address in nodes_def.items():
-            if not address.startswith(("http://", "https://")):
-                http_nodes_def[node_id] = f"http://{address}"
-            else:
-                http_nodes_def[node_id] = address
-
         driver = mprt.Driver(
-            http_nodes_def,
+            nodes_def,
             spu_nodes=spu_conf[0].node_ids,
         )
         main_func(driver)


### PR DESCRIPTION
Refactor the dataset loading process to support Keras datasets and simplify the dependencies in the example configuration. Adjust the driver initialization to ensure proper HTTP schema for node addresses.