### PR TITLE
Refactor to two-level architecture (DAPI & PAPI)

### DIFF
--- a/mplang/core/__init__.py
+++ b/mplang/core/__init__.py
@@ -35,7 +35,7 @@ from mplang.core.mask import Mask
 
 # Core object model
 from mplang.core.mpobject import MPContext, MPObject
-from mplang.core.mptype import MPType
+from mplang.core.mptype import MPType, Rank, Shape
 
 # Function handling
 from mplang.core.pfunc import PFunction
@@ -76,6 +76,8 @@ __all__ = [
     "MPType",
     "Mask",
     "PFunction",
+    "Rank",
+    "Shape",
     "TableLike",
     "TableType",
     "TensorLike",

--- a/mplang/device.py
+++ b/mplang/device.py
@@ -31,13 +31,11 @@ from typing import Any
 from jax.tree_util import tree_map
 
 import mplang.api as mapi
-from mplang import mpi, simp, smpc
+from mplang import simp
+from mplang.core import InterpContext, Mask, MPObject, primitive
 from mplang.core.context_mgr import set_ctx
-from mplang.core.interp import InterpContext
-from mplang.core.mask import Mask
-from mplang.core.mpobject import MPObject
-from mplang.core.primitive import primitive
 from mplang.runtime import Driver, Simulator
+from mplang.simp import mpi, smpc
 from mplang.utils.func_utils import normalize_fn
 
 
@@ -56,21 +54,6 @@ class DeviceInfo:
 
     configs: dict = field(default_factory=dict)
     """The device runtime configurations"""
-
-
-SAMPLE_DEVICE_CONF = {
-    "SP0": {
-        "type": "SPU",
-        "node_ids": ["node:0", "node:1", "node:2"],
-        "configs": {
-            "protocol": "SEMI2K",
-            "field": "FM128",
-            "enable_pphlo_profile": True,
-        },
-    },
-    "P0": {"type": "PPU", "node_ids": ["node:0"]},
-    "P1": {"type": "PPU", "node_ids": ["node:1"]},
-}
 
 
 def parse_device_conf(conf: dict) -> dict[str, DeviceInfo]:
@@ -127,7 +110,7 @@ def init(device_def: dict, nodes_def: dict | None = None) -> None:
     set_ctx(driver)
 
 
-function = primitive
+function = primitive.function
 
 
 class Utils:

--- a/mplang/random.py
+++ b/mplang/random.py
@@ -23,8 +23,7 @@ from jax.typing import ArrayLike
 
 import mplang.core.primitive as prim
 from mplang import simp
-from mplang.core.mpobject import MPObject
-from mplang.core.mptype import Shape
+from mplang.core import MPObject, Shape
 
 
 @prim.function

--- a/mplang/simp/mpi.py
+++ b/mplang/simp/mpi.py
@@ -17,13 +17,11 @@ from __future__ import annotations
 import logging
 
 import mplang.core.primitive as prim
-from mplang.core.mask import Mask
-from mplang.core.mpobject import MPObject
-from mplang.core.mptype import Rank
+from mplang.core import Mask, MPObject, Rank, function
 
 
 # scatter :: [m a] -> m Rank -> m a
-@prim.primitive
+@function
 def scatter_m(to_mask: Mask, root: Rank, args: list[MPObject]) -> MPObject:
     """Scatter the object from root to the parties in pmask.
 
@@ -55,7 +53,7 @@ def scatter_m(to_mask: Mask, root: Rank, args: list[MPObject]) -> MPObject:
 
 
 # gather :: m a -> m Rank -> [m a]
-@prim.primitive
+@function
 def gather_m(src_mask: Mask, root: Rank, arg: MPObject) -> list[MPObject]:
     """Gather the object from pmask'ed parties to the root party.
 
@@ -86,7 +84,7 @@ def gather_m(src_mask: Mask, root: Rank, arg: MPObject) -> list[MPObject]:
 
 
 # bcast :: m a -> m Rank -> m a
-@prim.function
+@function
 def bcast_m(pmask: Mask, root: Rank, obj: MPObject) -> MPObject:
     """Broadcast the object from the root party to the parties in pmask."""
     if obj.pmask is None:
@@ -102,7 +100,7 @@ def bcast_m(pmask: Mask, root: Rank, obj: MPObject) -> MPObject:
 
 
 # p2p :: m Rank -> m Rank -> m a -> m a
-@prim.function
+@function
 def p2p(frm: Rank, to: Rank, obj: MPObject) -> MPObject:
     """Point-to-point communication from frm to to."""
 
@@ -120,7 +118,7 @@ def p2p(frm: Rank, to: Rank, obj: MPObject) -> MPObject:
 
 
 # allgather :: m a -> [m a]
-@prim.function
+@function
 def allgather_m(pmask: Mask, arg: MPObject) -> list[MPObject]:
     """Gather the object from all parties in pmask and return a list of objects."""
 
@@ -132,9 +130,3 @@ def allgather_m(pmask: Mask, arg: MPObject) -> list[MPObject]:
 
     # TODO(jint): implement me.
     raise NotImplementedError("Allgather not implemented")
-
-
-@prim.function
-def pshfl(val: MPObject, index: MPObject) -> MPObject:
-    """Shuffle the value to the index party from the source party."""
-    return prim.pshfl(val, index)  # type: ignore[no-any-return]

--- a/tests/simp/test_mpi.py
+++ b/tests/simp/test_mpi.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import pytest
 
 import mplang
-import mplang.mpi as mpi
 import mplang.random as mpr
 import mplang.simp as simp
+import mplang.simp.mpi as mpi
 
 
 def eval_and_fetch(sim, fn, *args, **kwargs):
@@ -372,28 +371,6 @@ class TestMPICommunication:
         sent = mplang.evaluate(sim, mpi.p2p, 0, 2, large_data)
         large_data, sent = mplang.fetch(sim, (large_data, sent))
         assert sent == [None, None, 2**20]
-
-
-class TestPShfl:
-    """Test pshfl related functions"""
-
-    def test_pshfl_basic(self):
-        """Test basic pshfl_s functionality"""
-        num_parties = 10
-        sim = mplang.Simulator(num_parties)
-
-        src = mplang.evaluate(sim, mpr.prandint, 0, 100)
-        key = mplang.evaluate(sim, mpr.ukey, 42)
-        index = mplang.evaluate(sim, mpr.pperm, key)
-
-        # shuffle data with range, nothing changed.
-        shuffled = mplang.evaluate(sim, mpi.pshfl, src, index)
-
-        data, index, shuffled = mplang.fetch(sim, (src, index, shuffled))
-        data, index, shuffled = np.stack(data), np.stack(index), np.stack(shuffled)
-        np.testing.assert_array_equal(data[index], shuffled)
-
-    # TODO(jint): add shfl complicated
 
 
 if __name__ == "__main__":

--- a/tests/simp/test_simp.py
+++ b/tests/simp/test_simp.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+import mplang
+import mplang.random as mpr
+import mplang.simp as simp
+
+
+def eval_and_fetch(sim, fn, *args, **kwargs):
+    """Helper function to evaluate a function and fetch results."""
+    result = mplang.evaluate(sim, fn, *args, **kwargs)
+    return mplang.fetch(sim, result)
+
+
+class TestPShfl:
+    """Test pshfl related functions"""
+
+    def test_pshfl_basic(self):
+        """Test basic pshfl_s functionality"""
+        num_parties = 10
+        sim = mplang.Simulator(num_parties)
+
+        src = mplang.evaluate(sim, mpr.prandint, 0, 100)
+        key = mplang.evaluate(sim, mpr.ukey, 42)
+        index = mplang.evaluate(sim, mpr.pperm, key)
+
+        # shuffle data with range, nothing changed.
+        shuffled = mplang.evaluate(sim, simp.pshfl, src, index)
+
+        data, index, shuffled = mplang.fetch(sim, (src, index, shuffled))
+        data, index, shuffled = np.stack(data), np.stack(index), np.stack(shuffled)
+        np.testing.assert_array_equal(data[index], shuffled)
+
+    # TODO(jint): add shfl complicated
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/simp/test_smpc.py
+++ b/tests/simp/test_smpc.py
@@ -19,7 +19,7 @@ import pytest
 import mplang
 import mplang.random as mpr
 import mplang.simp as simp
-import mplang.smpc as smpc
+import mplang.simp.smpc as smpc
 
 
 class TestSmpcBasics:

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -16,10 +16,8 @@ import jax.numpy as jnp
 import pytest
 
 import mplang
-import mplang.mpi as mpi
 import mplang.random as mpr
 import mplang.simp as simp
-import mplang.smpc as smpc
 
 
 class TestTutorialBasicExamples:
@@ -42,14 +40,14 @@ class TestTutorialBasicExamples:
             y = simp.runAt(1, range_rand)()
 
             # both of them seal it
-            x_ = smpc.sealFrom(x, 0)
-            y_ = smpc.sealFrom(y, 1)
+            x_ = simp.sealFrom(x, 0)
+            y_ = simp.sealFrom(y, 1)
 
             # compare it securely
-            z_ = smpc.srun(lambda x, y: x < y)(x_, y_)
+            z_ = simp.srun(lambda x, y: x < y)(x_, y_)
 
             # reveal it to all
-            z = smpc.reveal(z_)
+            z = simp.reveal(z_)
 
             return x, y, z
 
@@ -105,12 +103,12 @@ class TestTutorialConditionalExamples:
             x = mpr.prandint(0, 10)
 
             # seal all parties private variable
-            xs_ = smpc.seal(x)
+            xs_ = simp.seal(x)
 
             # Sum it privately, and compare to 15
-            pred_ = smpc.srun(lambda xs: jnp.sum(jnp.stack(xs), axis=0) < 15)(xs_)
+            pred_ = simp.srun(lambda xs: jnp.sum(jnp.stack(xs), axis=0) < 15)(xs_)
             # Reveal the comparison result
-            pred = smpc.reveal(pred_)
+            pred = simp.reveal(pred_)
 
             # if the sum is greater than 15, return it, else return negate of it
             pos = simp.run(lambda x: x)(x)
@@ -201,10 +199,10 @@ class TestTutorialWhileLoopExamples:
 
             def cond(x: simp.MPObject):
                 # Seal all parties private
-                xs_ = smpc.seal(x)
+                xs_ = simp.seal(x)
                 # Sum them and reveal it
-                pred_ = smpc.srun(lambda i: sum(i) < 15)(xs_)
-                return smpc.reveal(pred_)
+                pred_ = simp.srun(lambda i: sum(i) < 15)(xs_)
+                return simp.reveal(pred_)
 
             def body(x: simp.MPObject):
                 return simp.run(lambda x: x + 1)(x)
@@ -314,14 +312,14 @@ class TestTutorialSimulationExamples:
             y = mpr.prandint(0, 10)
 
             # both of them seal it
-            x_ = smpc.sealFrom(x, 0)
-            y_ = smpc.sealFrom(y, 1)
+            x_ = simp.sealFrom(x, 0)
+            y_ = simp.sealFrom(y, 1)
 
             # compare it securely
-            z_ = smpc.srun(lambda x, y: x < y)(x_, y_)
+            z_ = simp.srun(lambda x, y: x < y)(x_, y_)
 
             # reveal it to all
-            z = smpc.reveal(z_)
+            z = simp.reveal(z_)
 
             return x, y, z
 
@@ -359,7 +357,7 @@ class TestTutorialErrorHandling:
         def mismatched_seal():
             x = mpr.prandint(0, 10)
             # Try to seal from non-existent party
-            return smpc.sealFrom(x, 5)
+            return simp.sealFrom(x, 5)
 
         with pytest.raises(Exception):  # Should raise some kind of error
             mplang.evaluate(sim2, mismatched_seal)
@@ -400,7 +398,7 @@ class TestTutorialDataStructures:
             val = simp.prank()  # Each party has its rank
 
             # Gather from all parties to party 0
-            gathered = mpi.gather_m((1 << 2) - 1, 0, val)
+            gathered = simp.gather_m((1 << 2) - 1, 0, val)
 
             return gathered
 

--- a/tutorials/0_basic.py
+++ b/tutorials/0_basic.py
@@ -17,7 +17,6 @@ from functools import partial
 
 import mplang
 import mplang.simp as simp
-import mplang.smpc as smpc
 
 
 # This is a simple example of how to use the MPLang library to create a
@@ -32,14 +31,14 @@ def millionaire():
     y = simp.runAt(1, range_rand)()
 
     # both of them seal it
-    x_ = smpc.sealFrom(x, 0)
-    y_ = smpc.sealFrom(y, 1)
+    x_ = simp.sealFrom(x, 0)
+    y_ = simp.sealFrom(y, 1)
 
     # compare it securely.
-    z_ = smpc.srun(lambda x, y: x < y)(x_, y_)
+    z_ = simp.srun(lambda x, y: x < y)(x_, y_)
 
     # reveal it to all.
-    z = smpc.reveal(z_)
+    z = simp.reveal(z_)
 
     return x, y, z
 
@@ -81,14 +80,14 @@ def millionaire_simp():
     x = simp.run(range_rand)()
 
     # all parties seal it, result a list of sealed values
-    xs_ = smpc.seal(x)
+    xs_ = simp.seal(x)
     # assert len(xs_) == 2  # Fixed from simp.cur_ctx().psize()
 
     # compare it securely.
-    z_ = smpc.srun(lambda x, y: x < y)(*xs_)
+    z_ = simp.srun(lambda x, y: x < y)(*xs_)
 
     # reveal it to all.
-    z = smpc.reveal(z_)
+    z = simp.reveal(z_)
 
     return x, z
 
@@ -134,7 +133,7 @@ print(
 
 # Here is a more complicated example that shows how to use `mplang.function` to
 # create a function that can be run at different parties, and how to use
-# `smpc` to securely compute the result.
+# `simp` to securely compute the result.
 
 
 @mplang.function
@@ -161,10 +160,10 @@ def myfun(*args, **kwargs):
     a = simp.runAt(0, lambda v: v * 2)(u)
     b = simp.runAt(1, lambda v: v + 5)(v)
 
-    x_ = smpc.sealFrom(x, 0)
-    y_ = smpc.sealFrom(y, 1)
-    z_ = smpc.srun(lambda x, y: x < y)(x_, y_)
-    c = smpc.reveal(z_)
+    x_ = simp.sealFrom(x, 0)
+    y_ = simp.sealFrom(y, 1)
+    z_ = simp.srun(lambda x, y: x < y)(x_, y_)
+    c = simp.reveal(z_)
 
     # return complicated result.
     return a, [b, c2], {"c": c, "c3": c3}

--- a/tutorials/1_condition.py
+++ b/tutorials/1_condition.py
@@ -17,7 +17,6 @@ import jax.numpy as jnp
 import mplang
 import mplang.random as mpr
 import mplang.simp as simp
-import mplang.smpc as smpc
 
 
 @mplang.function
@@ -48,13 +47,13 @@ def negate_if_shared_cond():
     x = mpr.prandint(0, 10)
 
     # seal all parties private variable.
-    xs_ = smpc.seal(x)
+    xs_ = simp.seal(x)
     # assert len(xs_) == 2  # Fixed from simp.cur_ctx().psize()
 
     # Sum it privately, and compare to 15
-    pred_ = smpc.srun(lambda xs: jnp.sum(jnp.stack(xs), axis=0) < 15)(xs_)
+    pred_ = simp.srun(lambda xs: jnp.sum(jnp.stack(xs), axis=0) < 15)(xs_)
     # Reveal the comparison result.
-    pred = smpc.reveal(pred_)
+    pred = simp.reveal(pred_)
 
     # if the sum is greater than 10, return it, else return negate of it.
     pos = simp.run(lambda x: x)(x)

--- a/tutorials/2_whileloop.py
+++ b/tutorials/2_whileloop.py
@@ -18,7 +18,6 @@ import jax.numpy as jnp
 import mplang
 import mplang.random as mpr
 import mplang.simp as simp
-import mplang.smpc as smpc
 
 
 @mplang.function
@@ -46,10 +45,10 @@ def while_sum_greater():
 
     def cond(x: simp.MPObject):
         # Seal all parties private
-        xs_ = smpc.seal(x)
+        xs_ = simp.seal(x)
         # Sum them and reveal it.
-        pred_ = smpc.srun(lambda i: sum(i) < 15)(xs_)
-        return smpc.reveal(pred_)
+        pred_ = simp.srun(lambda i: sum(i) < 15)(xs_)
+        return simp.reveal(pred_)
 
     def body(x: simp.MPObject):
         return simp.run(lambda x: x + 1)(x)
@@ -77,11 +76,11 @@ def while_until_ascending():
 
     def cond(x: simp.MPObject):
         # seal it, or we can not directly compare all parties numbers.
-        xs_ = smpc.seal(x)
+        xs_ = simp.seal(x)
         # check if parties' numbers are accending
-        p_ = smpc.srun(not_ascending)(xs_)
+        p_ = simp.srun(not_ascending)(xs_)
         # reveal the result, all parties agree on it.
-        return smpc.reveal(p_)
+        return simp.reveal(p_)
 
     def body(x: simp.MPObject):
         # randomize a new number

--- a/tutorials/4_simulation.py
+++ b/tutorials/4_simulation.py
@@ -17,7 +17,7 @@ import random
 import mplang
 import mplang.device as mpd
 import mplang.random as mpr
-import mplang.smpc as smpc
+import mplang.simp as simp
 
 
 def randint(lo, hi):
@@ -35,14 +35,14 @@ def millionaire():
     y = mpr.prandint(0, 10)
 
     # both of them seal it
-    x_ = smpc.sealFrom(x, 0)
-    y_ = smpc.sealFrom(y, 1)
+    x_ = simp.sealFrom(x, 0)
+    y_ = simp.sealFrom(y, 1)
 
     # compare it seally.
-    z_ = smpc.srun(lambda x, y: x < y)(x_, y_)
+    z_ = simp.srun(lambda x, y: x < y)(x_, y_)
 
     # reveal it to all.
-    z = smpc.reveal(z_)
+    z = simp.reveal(z_)
 
     return x, y, z
 

--- a/tutorials/5_ir_dump.py
+++ b/tutorials/5_ir_dump.py
@@ -15,8 +15,8 @@
 
 import mplang
 from mplang import random as mpr
-from mplang import smpc
 from mplang.core import mpir
+from mplang.simp import smpc
 
 
 @mplang.function

--- a/tutorials/7_stdio.py
+++ b/tutorials/7_stdio.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import mplang
 import mplang.simp as simp
-import mplang.smpc as smpc
+from mplang.core import TensorType
 from mplang.frontend import builtin
 
 
@@ -35,15 +35,15 @@ def save_data():
 
 @mplang.function
 def load_data():
-    tensor_info = mplang.core.TensorType(shape=(2, 2), dtype=jnp.float32)
+    tensor_info = TensorType(shape=(2, 2), dtype=jnp.float32)
 
     x = simp.runAt(0, builtin.read)("tmp/x.npy", tensor_info)
     y = simp.runAt(1, builtin.read)("tmp/y.npy", tensor_info)
 
-    x_ = smpc.sealFrom(x, 0)
-    y_ = smpc.sealFrom(y, 1)
-    z_ = smpc.srun(lambda a, b: a + b)(x_, y_)
-    z = smpc.reveal(z_)
+    x_ = simp.sealFrom(x, 0)
+    y_ = simp.sealFrom(y, 1)
+    z_ = simp.srun(lambda a, b: a + b)(x_, y_)
+    z = simp.reveal(z_)
 
     return z
 

--- a/tutorials/8_phe.py
+++ b/tutorials/8_phe.py
@@ -24,7 +24,6 @@ This tutorial demonstrates a three-party computation using PHE:
 """
 
 import mplang
-import mplang.mpi as mpi
 import mplang.simp as simp
 from mplang.frontend import phe
 
@@ -41,14 +40,14 @@ def three_party_phe_sum():
 
     # Step 3: Party 0 broadcasts public key to all parties
     world_mask = mplang.Mask.all(3)
-    pkey_bcasted = mpi.bcast_m(world_mask, 0, pkey)
+    pkey_bcasted = simp.bcast_m(world_mask, 0, pkey)
 
     # Step 4: Each party encrypts their data
     encrypted = simp.run(phe.encrypt)(data, pkey_bcasted)
 
     # Step 5: All parties send encrypted data to Party 0
     # Gather all encrypted data at Party 0
-    e0, e1, e2 = mpi.gather_m(world_mask, 0, encrypted)
+    e0, e1, e2 = simp.gather_m(world_mask, 0, encrypted)
 
     # Step 6: Party 0 computes sum and decrypts
     sum_e0_e1 = simp.runAt(0, phe.add)(e0, e1)


### PR DESCRIPTION
Introduce a two-level architecture by refactoring the codebase to utilize the `simp` module instead of `smpc`, enhancing clarity and maintainability. 