### PR TITLE
Move packing/unpacking to built-in and add global symbol support

### DIFF
--- a/mplang/backend/base.py
+++ b/mplang/backend/base.py
@@ -138,10 +138,18 @@ def _validate_tensor_arg(
         val_shape = getattr(value, "shape", ())
         duck_dtype = getattr(value, "dtype", None)
 
-    if tuple(spec.shape) != tuple(val_shape):
+    if len(spec.shape) != len(val_shape):
         raise ValueError(
-            f"kernel {fn_type} input[{arg_index}] shape mismatch: got {val_shape}, expected {spec.shape}"
+            f"kernel {fn_type} input[{arg_index}] rank mismatch: got {val_shape}, expected {spec.shape}"
         )
+
+    for dim_idx, (spec_dim, val_dim) in enumerate(
+        zip(spec.shape, val_shape, strict=True)
+    ):
+        if spec_dim >= 0 and spec_dim != val_dim:
+            raise ValueError(
+                f"kernel {fn_type} input[{arg_index}] shape mismatch at dim {dim_idx}: got {val_dim}, expected {spec_dim}"
+            )
 
     try:
         val_dtype = DType.from_any(duck_dtype)

--- a/mplang/backend/builtin.py
+++ b/mplang/backend/builtin.py
@@ -23,6 +23,7 @@ import pandas as pd
 from mplang.backend.base import cur_kctx, kernel_def
 from mplang.core.pfunc import PFunction
 from mplang.core.table import TableType
+from mplang.core.tensor import TensorType
 from mplang.utils import table_utils
 
 
@@ -160,3 +161,52 @@ def _debug_print(pfunc: PFunction, val: Any) -> Any:
     ctx = cur_kctx()
     print(f"[debug_print][rank={ctx.rank}] {prefix}{_summ(val)}")
     return val
+
+
+@kernel_def("builtin.pack")
+def _pack(pfunc: PFunction, value: Any) -> Any:
+    outs_info = pfunc.outs_info
+    if len(outs_info) != 1:
+        raise ValueError("builtin.pack expects single output type")
+    out_ty = outs_info[0]
+    if not isinstance(out_ty, TensorType):
+        raise TypeError("builtin.pack must return TensorType")
+    if out_ty.dtype.numpy_dtype() != np.uint8:
+        raise TypeError("builtin.pack output dtype must be uint8")
+
+    if isinstance(value, pd.DataFrame):
+        csv_bytes = table_utils.dataframe_to_csv(value)
+        return np.frombuffer(csv_bytes, dtype=np.uint8)
+
+    arr = _to_numpy(value)
+    return np.frombuffer(arr.tobytes(order="C"), dtype=np.uint8)
+
+
+@kernel_def("builtin.unpack")
+def _unpack(pfunc: PFunction, packed: Any) -> Any:
+    outs_info = pfunc.outs_info
+    if len(outs_info) != 1:
+        raise ValueError("builtin.unpack expects single output type")
+    out_ty = outs_info[0]
+
+    b = np.asarray(packed, dtype=np.uint8).reshape(-1)
+
+    if isinstance(out_ty, TensorType):
+        np_dtype = out_ty.dtype.numpy_dtype()
+        shape = tuple(out_ty.shape)
+        if any(dim < 0 for dim in shape):
+            raise ValueError("builtin.unpack does not support dynamic tensor shapes")
+        elem_count = int(np.prod(shape)) if len(shape) > 0 else 1
+        expected = elem_count * np.dtype(np_dtype).itemsize
+        if b.size != expected:
+            raise ValueError(
+                f"unpack size mismatch: got {b.size} bytes, expect {expected} for {np_dtype} {shape}"
+            )
+        arr = np.frombuffer(b.tobytes(), dtype=np_dtype)
+        return arr.reshape(shape)
+
+    if isinstance(out_ty, TableType):
+        csv_bytes = b.tobytes()
+        return table_utils.csv_to_dataframe(csv_bytes)
+
+    raise TypeError("builtin.unpack output type must be TensorType or TableType")

--- a/mplang/device.py
+++ b/mplang/device.py
@@ -35,7 +35,7 @@ from mplang.core import InterpContext, MPObject, primitive
 from mplang.core.cluster import ClusterSpec, Device
 from mplang.core.context_mgr import cur_ctx
 from mplang.core.tensor import TensorType
-from mplang.frontend import crypto, ibis_cc, jax_cc, tee
+from mplang.frontend import builtin, crypto, ibis_cc, jax_cc, tee
 from mplang.frontend.base import FeOperation
 from mplang.frontend.ibis_cc import IbisCompiler
 from mplang.frontend.jax_cc import JaxCompiler
@@ -211,11 +211,11 @@ def _d2d(to_dev_id: str, obj: MPObject) -> MPObject:
         sess_p, sess_t = _ensure_tee_session(frm_dev_id, to_dev_id, frm_rank, tee_rank)
         # Bytes-only path: pack -> enc -> p2p -> dec -> unpack (with static out type)
         obj_ty = TensorType.from_obj(obj)
-        b = simp.runAt(frm_rank, crypto.pack)(obj)
+        b = simp.runAt(frm_rank, builtin.pack)(obj)
         ct = simp.runAt(frm_rank, crypto.enc)(b, sess_p)
         ct_at_tee = mpi.p2p(frm_rank, tee_rank, ct)
         b_at_tee = simp.runAt(tee_rank, crypto.dec)(ct_at_tee, sess_t)
-        pt_at_tee = simp.runAt(tee_rank, crypto.unpack)(b_at_tee, obj_ty)
+        pt_at_tee = simp.runAt(tee_rank, builtin.unpack)(b_at_tee, out_ty=obj_ty)
         return tree_map(partial(_set_devid, dev_id=to_dev_id), pt_at_tee)  # type: ignore[no-any-return]
     elif frm_to_pair == ("TEE", "PPU"):
         # Transparent encryption from TEE to a specific PPU using the reverse-direction session key
@@ -225,11 +225,11 @@ def _d2d(to_dev_id: str, obj: MPObject) -> MPObject:
         # Ensure bidirectional session established for this pair
         sess_p, sess_t = _ensure_tee_session(to_dev_id, frm_dev_id, ppu_rank, tee_rank)
         obj_ty = TensorType.from_obj(obj)
-        b = simp.runAt(tee_rank, crypto.pack)(obj)
+        b = simp.runAt(tee_rank, builtin.pack)(obj)
         ct = simp.runAt(tee_rank, crypto.enc)(b, sess_t)
         ct_at_ppu = mpi.p2p(tee_rank, ppu_rank, ct)
         b_at_ppu = simp.runAt(ppu_rank, crypto.dec)(ct_at_ppu, sess_p)
-        pt_at_ppu = simp.runAt(ppu_rank, crypto.unpack)(b_at_ppu, obj_ty)
+        pt_at_ppu = simp.runAt(ppu_rank, builtin.unpack)(b_at_ppu, out_ty=obj_ty)
         return tree_map(partial(_set_devid, dev_id=to_dev_id), pt_at_ppu)  # type: ignore[no-any-return]
     else:
         supported = [

--- a/mplang/runtime/data_providers.py
+++ b/mplang/runtime/data_providers.py
@@ -1,0 +1,279 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import ParseResult, urlparse
+
+import numpy as np
+import pandas as pd
+
+from mplang.backend.base import KernelContext
+from mplang.core.table import TableType
+from mplang.core.tensor import TensorType
+from mplang.utils import table_utils
+
+
+@dataclass(frozen=True)
+class ResolvedURI:
+    """Result of resolving a resource path into a normalized form.
+
+    Attributes:
+      scheme: The URI scheme (e.g., 'file', 's3', 'mem', 'var', 'secret').
+      raw: The original path string as provided by the user.
+      parsed: The ParseResult if a scheme was present; otherwise None.
+      local_path: For file paths: concrete filesystem path (absolute or as given).
+    """
+
+    scheme: str
+    raw: str
+    parsed: ParseResult | None
+    local_path: str | None
+
+
+def resolve_uri(path: str) -> ResolvedURI:
+    """Resolve a user-provided resource location into a normalized URI form.
+
+    This helper accepts both plain filesystem paths and full URIs, returning a
+    lightweight ``ResolvedURI`` that captures:
+      - ``scheme``: the canonical, lower-cased URI scheme.
+      - ``raw``: the original user input (kept verbatim for round-tripping).
+      - ``parsed``: the ``urllib.parse.ParseResult`` when a scheme is present; ``None`` otherwise.
+      - ``local_path``: a best-effort filesystem path for ``file`` resources; otherwise ``None``.
+
+    Schema (scheme) and standard
+    - Syntax follows RFC 3986 (URI Generic Syntax). We detect a URI when the input contains ``"://"``.
+    - When no scheme is present, we default to ``file`` and set ``local_path`` to the input string as-is.
+    - Supported schemes out-of-the-box (pluggable via ``register_provider``):
+        * ``file``: local filesystem paths (default when no scheme is provided)
+        * ``mem``: in-memory, per-runtime key-value storage
+        * ``var``: per-runtime/session variables
+        * ``s3``: placeholder for object storage (requires external plugin)
+        * ``secret``: placeholder for secret manager/KMS (requires external plugin)
+
+    Behavior notes for ``file`` scheme
+    - ``file:///abs/path`` and ``/abs/path`` are both treated as absolute paths on POSIX.
+    - ``file://<host>/abs/path`` will ignore ``<host>`` on POSIX; we keep a path derived from ``ParseResult.path``.
+    - ``local_path`` is only populated for the ``file`` scheme; for other schemes it's ``None``.
+
+    Examples
+    >>> resolve_uri("data/train.npy")
+    ResolvedURI(scheme='file', raw='data/train.npy', parsed=None, local_path='data/train.npy')
+
+    >>> resolve_uri("/abs/path/table.csv")
+    ResolvedURI(scheme='file', raw='/abs/path/table.csv', parsed=None, local_path='/abs/path/table.csv')
+
+    >>> resolve_uri("file:///tmp/x.npy").scheme
+    'file'
+
+    >>> resolve_uri("mem://ds1").scheme
+    'mem'
+
+    >>> resolve_uri("var://session/input").scheme
+    'var'
+
+    >>> resolve_uri("s3://bucket/key").scheme
+    's3'
+
+    Returns
+    -------
+    ResolvedURI
+        A normalized representation suitable for provider lookups and I/O.
+    """
+
+    if "://" not in path:
+        return ResolvedURI("file", path, None, path)
+
+    pr = urlparse(path)
+    scheme = pr.scheme or "file"
+    local_path: str | None = None
+    if scheme == "file":
+        # file://<host>/abs/path or file:///abs/path; ignore host on posix
+        # Keep it simple: join netloc and path when netloc present
+        local_path = pr.path
+        if pr.netloc and not local_path.startswith("/"):
+            local_path = f"//{pr.netloc}/{pr.path}"
+    return ResolvedURI(scheme, path, pr, local_path)
+
+
+class DataProvider:
+    """Abstract base for data providers.
+
+    Minimal contract: read/write by URI and type spec. Providers may ignore the
+    type spec but SHOULD validate when feasible.
+    """
+
+    def read(
+        self, uri: ResolvedURI, out_spec: TensorType | TableType, *, ctx: KernelContext
+    ) -> Any:
+        raise NotImplementedError
+
+    def write(self, uri: ResolvedURI, value: Any, *, ctx: KernelContext) -> None:
+        raise NotImplementedError
+
+
+_REGISTRY: dict[str, DataProvider] = {}
+
+
+def register_provider(
+    scheme: str, provider: DataProvider, *, replace: bool = False
+) -> None:
+    key = scheme.lower()
+    if not replace and key in _REGISTRY:
+        raise ValueError(f"provider already registered for scheme: {scheme}")
+    _REGISTRY[key] = provider
+
+
+def get_provider(scheme: str) -> DataProvider | None:
+    return _REGISTRY.get(scheme.lower())
+
+
+# ---------------- Default Providers ----------------
+
+
+class FileProvider(DataProvider):
+    """Local filesystem provider.
+
+    For tables: CSV bytes via table_utils.
+    For tensors: NumPy .npy via np.load/np.save.
+    """
+
+    def read(
+        self, uri: ResolvedURI, out_spec: TensorType | TableType, *, ctx: KernelContext
+    ) -> Any:
+        path = uri.local_path or uri.raw
+        if isinstance(out_spec, TableType):
+            with open(path, "rb") as f:
+                csv_bytes = f.read()
+            return table_utils.csv_to_dataframe(csv_bytes)
+        # tensor path
+        return np.load(path)
+
+    def write(self, uri: ResolvedURI, value: Any, *, ctx: KernelContext) -> None:
+        import os
+
+        path = uri.local_path or uri.raw
+        dir_name = os.path.dirname(path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
+        # Table-like to CSV bytes
+        if hasattr(value, "__dataframe__") or isinstance(value, pd.DataFrame):
+            csv_bytes = table_utils.dataframe_to_csv(value)  # type: ignore
+            with open(path, "wb") as f:
+                f.write(csv_bytes)
+            return
+        # Tensor-like via numpy
+        np.save(path, np.asarray(value))
+
+
+class _KeyedPocket:
+    """Small helper to keep a dict in KernelContext.state under a namespaced key."""
+
+    def __init__(self, ns: str):
+        self.ns = ns
+
+    def get_map(self, ctx: KernelContext) -> dict[str, Any]:
+        pocket = ctx.state.setdefault("resource.providers", {})
+        store = pocket.get(self.ns)
+        if store is None:
+            store = {}
+            pocket[self.ns] = store
+        return store  # type: ignore[return-value]
+
+
+class MemProvider(DataProvider):
+    """In-memory per-runtime KV provider (per rank, per session/runtime)."""
+
+    def __init__(self) -> None:
+        self._pocket = _KeyedPocket("mem")
+
+    def read(
+        self, uri: ResolvedURI, out_spec: TensorType | TableType, *, ctx: KernelContext
+    ) -> Any:
+        store = self._pocket.get_map(ctx)
+        key = uri.raw
+        if key not in store:
+            raise FileNotFoundError(f"mem resource not found: {key}")
+        return store[key]
+
+    def write(self, uri: ResolvedURI, value: Any, *, ctx: KernelContext) -> None:
+        store = self._pocket.get_map(ctx)
+        store[uri.raw] = value
+
+
+class VarProvider(DataProvider):
+    """Session/runtime variable provider.
+
+    Default implementation uses per-runtime state pocket; integration with HTTP
+    session symbols can be added by pre-populating this pocket.
+    """
+
+    def __init__(self) -> None:
+        self._pocket = _KeyedPocket("var")
+
+    def read(
+        self, uri: ResolvedURI, out_spec: TensorType | TableType, *, ctx: KernelContext
+    ) -> Any:
+        store = self._pocket.get_map(ctx)
+        key = uri.raw
+        if key not in store:
+            raise FileNotFoundError(f"var symbol not found: {key}")
+        return store[key]
+
+    def write(self, uri: ResolvedURI, value: Any, *, ctx: KernelContext) -> None:
+        store = self._pocket.get_map(ctx)
+        store[uri.raw] = value
+
+
+class S3Provider(DataProvider):
+    """Placeholder S3 provider. Install external plugin to enable."""
+
+    def read(
+        self, uri: ResolvedURI, out_spec: TensorType | TableType, *, ctx: KernelContext
+    ) -> Any:
+        raise NotImplementedError(
+            "S3 provider not installed. Provide an external plugin via register_provider('s3', ...) ."
+        )
+
+    def write(self, uri: ResolvedURI, value: Any, *, ctx: KernelContext) -> None:
+        raise NotImplementedError(
+            "S3 provider not installed. Provide an external plugin via register_provider('s3', ...) ."
+        )
+
+
+class SecretProvider(DataProvider):
+    """Placeholder secret provider. Integrate with KMS/secret manager via plugin."""
+
+    def read(
+        self, uri: ResolvedURI, out_spec: TensorType | TableType, *, ctx: KernelContext
+    ) -> Any:
+        raise NotImplementedError(
+            "secret provider not installed. Provide an external plugin via register_provider('secret', ...) ."
+        )
+
+    def write(self, uri: ResolvedURI, value: Any, *, ctx: KernelContext) -> None:
+        raise NotImplementedError(
+            "secret provider not installed. Provide an external plugin via register_provider('secret', ...) ."
+        )
+
+
+# Register default providers
+register_provider("file", FileProvider())
+register_provider("mem", MemProvider())
+register_provider("var", VarProvider())
+# Stubs to signal missing providers explicitly (can be overridden by plugins)
+register_provider("s3", S3Provider())
+register_provider("secret", SecretProvider())

--- a/mplang/runtime/resource.py
+++ b/mplang/runtime/resource.py
@@ -36,7 +36,7 @@ from mplang.backend import (  # noqa: F401
     stablehlo,
     tee,
 )
-from mplang.backend.base import create_runtime
+from mplang.backend.base import BackendRuntime, create_runtime
 from mplang.backend.spu import PFunction  # type: ignore
 from mplang.core.expr.ast import Expr
 from mplang.core.expr.evaluator import IEvaluator, create_evaluator
@@ -97,6 +97,9 @@ class Session:
 
 # Global session storage
 _sessions: dict[str, Session] = {}
+
+# Service-level global symbol table (process-local for this server)
+_global_symbols: dict[str, Symbol] = {}
 
 
 # Session Management
@@ -223,6 +226,11 @@ def execute_computation(
     # Build evaluator
     # Explicit per-rank backend runtime (deglobalized)
     runtime = create_runtime(rank, session.communicator.world_size)
+    # Inject global symbol storage into backend runtime state so that
+    # symbols:// provider can access it during builtin.read/write.
+    if isinstance(runtime, BackendRuntime):
+        pocket = runtime.state.setdefault("resource.providers", {})
+        pocket["symbols"] = _global_symbols
     evaluator: IEvaluator = create_evaluator(
         rank=rank, env=bindings, comm=session.communicator, runtime=runtime
     )
@@ -272,6 +280,39 @@ def execute_computation(
             )
         for name, val in zip(output_names, results, strict=True):
             session.symbols[name] = Symbol(name=name, mptype={}, data=val)
+
+
+# Global symbol CRUD (service-level)
+def create_global_symbol(name: str, mptype: Any, data: str) -> Symbol:
+    """Create or update a global symbol in the service-level table.
+
+    The `data` is base64-encoded pickled Python object, same as session symbols.
+    """
+    try:
+        data_bytes = base64.b64decode(data)
+        obj = pickle.loads(data_bytes)
+    except Exception as e:
+        raise InvalidRequestError(f"Invalid global symbol data encoding: {e!s}") from e
+
+    sym = Symbol(name, mptype, obj)
+    _global_symbols[name] = sym
+    return sym
+
+
+def get_global_symbol(name: str) -> Symbol | None:
+    return _global_symbols.get(name)
+
+
+def list_global_symbols() -> list[str]:
+    return list(_global_symbols.keys())
+
+
+def delete_global_symbol(name: str) -> bool:
+    if name in _global_symbols:
+        del _global_symbols[name]
+        logging.info(f"Global symbol {name} deleted")
+        return True
+    return False
 
 
 # Symbol Management

--- a/mplang/runtime/server.py
+++ b/mplang/runtime/server.py
@@ -29,11 +29,71 @@ from pydantic import BaseModel
 from mplang.core.mpir import Reader
 from mplang.protos.v1alpha1 import mpir_pb2
 from mplang.runtime import resource
+from mplang.runtime.data_providers import DataProvider, register_provider
 from mplang.runtime.exceptions import InvalidRequestError, ResourceNotFound
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+
+
+class _SymbolsProvider(DataProvider):
+    """Server-local symbols provider backed by BackendRuntime.state."""
+
+    @staticmethod
+    def _candidate_keys(uri) -> list[str]:  # type: ignore[override]
+        keys: list[str] = []
+        parsed = getattr(uri, "parsed", None)
+        if parsed is not None and getattr(parsed, "scheme", None) == "symbols":
+            alt = parsed.netloc or parsed.path.lstrip("/")  # type: ignore[attr-defined]
+            if alt:
+                keys.append(alt)
+        keys.append(uri.raw)
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        result: list[str] = []
+        for k in keys:
+            if k not in seen:
+                seen.add(k)
+                result.append(k)
+        return result
+
+    def read(self, uri, out_spec, *, ctx):  # type: ignore[override]
+        for key in self._candidate_keys(uri):
+            sym = resource.get_global_symbol(key)
+            if sym is not None:
+                return sym.data
+            val = resource._global_symbols.get(key)  # type: ignore[attr-defined]
+            if val is not None:
+                if hasattr(val, "data"):
+                    return val.data  # type: ignore[attr-defined]
+                return val
+        raise ResourceNotFound(f"Global symbol '{uri.raw}' not found")
+
+    def write(self, uri, value, *, ctx):  # type: ignore[override]
+        keys = self._candidate_keys(uri)
+        if not keys:
+            raise ResourceNotFound(f"Global symbol '{uri.raw}' not found")
+        primary = keys[0]
+        try:
+            data_b64 = base64.b64encode(pickle.dumps(value)).decode("utf-8")
+        except Exception as e:  # pragma: no cover - defensive
+            raise InvalidRequestError(
+                f"Failed to encode value for symbols:// write: {e!s}"
+            ) from e
+
+        sym = resource.create_global_symbol(primary, {}, data_b64)
+        # Populate alias entries (if any) so future lookups succeed (share same Symbol instance).
+        for alias in keys[1:]:
+            resource._global_symbols[alias] = resource.Symbol(  # type: ignore[attr-defined]
+                name=alias,
+                mptype=sym.mptype,
+                data=sym.data,
+            )
+
+
+# Register symbols provider explicitly for server runtime
+register_provider("symbols", _SymbolsProvider())
 
 
 @app.exception_handler(ResourceNotFound)
@@ -137,6 +197,12 @@ class SessionListResponse(BaseModel):
 
 class ComputationListResponse(BaseModel):
     computations: list[str]
+
+
+class GlobalSymbolResponse(BaseModel):
+    name: str
+    mptype: dict
+    data: str
 
 
 @app.get("/health")
@@ -301,6 +367,39 @@ def delete_symbol(session_name: str, symbol_name: str) -> dict[str, str]:
         raise ResourceNotFound(
             f"Symbol '{symbol_name}' not found in session '{session_name}'"
         )
+
+
+# Global Symbols endpoints
+@app.put("/api/v1/symbols/{symbol_name}", response_model=GlobalSymbolResponse)
+def create_global_symbol(
+    symbol_name: str, request: CreateSymbolRequest
+) -> GlobalSymbolResponse:
+    validate_name(symbol_name, "symbol")
+    sym = resource.create_global_symbol(symbol_name, request.mptype, request.data)
+    return GlobalSymbolResponse(name=sym.name, mptype=sym.mptype, data=request.data)
+
+
+@app.get("/api/v1/symbols/{symbol_name}", response_model=GlobalSymbolResponse)
+def get_global_symbol(symbol_name: str) -> GlobalSymbolResponse:
+    sym = resource.get_global_symbol(symbol_name)
+    if not sym:
+        raise ResourceNotFound(f"Global symbol '{symbol_name}' not found")
+    data_bytes = pickle.dumps(sym.data)
+    data_b64 = base64.b64encode(data_bytes).decode("utf-8")
+    return GlobalSymbolResponse(name=sym.name, mptype=sym.mptype, data=data_b64)
+
+
+@app.get("/api/v1/symbols")
+def list_global_symbols() -> dict[str, list[str]]:
+    return {"symbols": resource.list_global_symbols()}
+
+
+@app.delete("/api/v1/symbols/{symbol_name}")
+def delete_global_symbol(symbol_name: str) -> dict[str, str]:
+    if resource.delete_global_symbol(symbol_name):
+        return {"message": f"Global symbol '{symbol_name}' deleted successfully"}
+    else:
+        raise ResourceNotFound(f"Global symbol '{symbol_name}' not found")
 
 
 # Communication endpoints

--- a/tests/frontend/test_builtin_pack.py
+++ b/tests/frontend/test_builtin_pack.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import mplang
+import mplang.simp as simp
+from mplang.core.dtype import UINT8, DType
+from mplang.core.table import TableType
+from mplang.core.tensor import TensorType
+from mplang.frontend import builtin
+from mplang.utils import table_utils
+
+
+@pytest.mark.integration
+def test_builtin_pack_unpack_tensor_runtime() -> None:
+    sim = mplang.Simulator.simple(1)
+    arr = np.arange(6, dtype=np.int32).reshape(2, 3)
+    tensor_ty = TensorType.from_obj(arr)
+
+    @mplang.function
+    def fn():
+        x = simp.runAt(0, lambda: np.arange(6, dtype=np.int32).reshape(2, 3))()
+        packed = simp.runAt(0, builtin.pack)(x)
+        unpacked = simp.runAt(0, builtin.unpack)(packed, out_ty=tensor_ty)
+        return x, packed, unpacked
+
+    x, packed, unpacked = mplang.evaluate(sim, fn)
+    x_v, packed_v, unpacked_v = mplang.fetch(sim, (x, packed, unpacked))
+    np.testing.assert_array_equal(x_v[0], unpacked_v[0])
+    assert packed_v[0].dtype == np.uint8
+    assert packed_v[0].ndim == 1
+    assert packed_v[0].size == arr.size * arr.dtype.itemsize
+    assert packed.mptype._type.dtype == UINT8
+    assert packed.mptype._type.shape == (-1,)
+    assert unpacked.mptype._type == tensor_ty
+
+
+@pytest.mark.integration
+def test_builtin_pack_unpack_table_runtime() -> None:
+    sim = mplang.Simulator.simple(1)
+    data = {"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]}
+    table_schema = TableType.from_pairs([
+        ("a", DType.from_any("int64")),
+        ("b", DType.from_any("float64")),
+    ])
+    expected_bytes = table_utils.dataframe_to_csv(pd.DataFrame(data))
+
+    @mplang.function
+    def fn():
+        table = simp.constant(pd.DataFrame(data))
+        packed = simp.runAt(0, builtin.pack)(table)
+        unpacked = simp.runAt(0, builtin.unpack)(packed, out_ty=table_schema)
+        return packed, unpacked
+
+    packed, unpacked = mplang.evaluate(sim, fn)
+    packed_v, unpacked_v = mplang.fetch(sim, (packed, unpacked))
+    pd.testing.assert_frame_equal(unpacked_v[0], pd.DataFrame(data))
+    assert packed_v[0].dtype == np.uint8
+    assert packed_v[0].ndim == 1
+    assert packed_v[0].tobytes() == expected_bytes
+    assert packed.mptype._type.dtype == UINT8
+    assert packed.mptype._type.shape == (-1,)
+    assert unpacked.mptype._type == table_schema

--- a/tests/frontend/test_crypto_tee.py
+++ b/tests/frontend/test_crypto_tee.py
@@ -16,7 +16,8 @@ import numpy as np
 
 import mplang
 import mplang.simp as simp
-from mplang.frontend import crypto, tee
+from mplang.core.tensor import TensorType
+from mplang.frontend import builtin, crypto, tee
 
 
 def _demo_flow():
@@ -54,18 +55,21 @@ def _demo_flow():
     # Encrypt at data parties and decrypt at TEE (bytes-only path)
     x0 = simp.runAt(P0, lambda: np.array([10, 20, 30], dtype=np.uint8))()
     x1 = simp.runAt(P1, lambda: np.array([1, 2, 3], dtype=np.uint8))()
-    b0 = simp.runAt(P0, crypto.pack)(x0)
-    b1 = simp.runAt(P1, crypto.pack)(x1)
+    b0 = simp.runAt(P0, builtin.pack)(x0)
+    b1 = simp.runAt(P1, builtin.pack)(x1)
     c0 = simp.runAt(P0, crypto.enc)(b0, sess0_v)
     c1 = simp.runAt(P1, crypto.enc)(b1, sess1_v)
     c0_at_tee = simp.p2p(P0, P2, c0)
     c1_at_tee = simp.p2p(P1, P2, c1)
     b0_at_tee = simp.runAt(P2, crypto.dec)(c0_at_tee, sess0_t)
     b1_at_tee = simp.runAt(P2, crypto.dec)(c1_at_tee, sess1_t)
-    from mplang.core.tensor import TensorType
 
-    p0 = simp.runAt(P2, crypto.unpack)(b0_at_tee, TensorType(x0.dtype, x0.shape))
-    p1 = simp.runAt(P2, crypto.unpack)(b1_at_tee, TensorType(x1.dtype, x1.shape))
+    p0 = simp.runAt(P2, builtin.unpack)(
+        b0_at_tee, out_ty=TensorType(x0.dtype, x0.shape)
+    )
+    p1 = simp.runAt(P2, builtin.unpack)(
+        b1_at_tee, out_ty=TensorType(x1.dtype, x1.shape)
+    )
     return p0, p1
 
 

--- a/tests/integration/test_crypto_roundtrip.py
+++ b/tests/integration/test_crypto_roundtrip.py
@@ -22,7 +22,8 @@ import pytest
 
 import mplang
 import mplang.simp as simp
-from mplang.frontend import crypto
+from mplang.core.tensor import TensorType
+from mplang.frontend import builtin, crypto
 
 pytestmark = pytest.mark.integration
 
@@ -77,10 +78,10 @@ def test_pack_unpack_roundtrip_various():
         outs = []
         for _idx, (shape, dt) in enumerate(shapes_dtypes):
             arr = simp.runAt(0, lambda s=shape, d=dt: np.zeros(s, dtype=d))()
-            packed = simp.runAt(0, crypto.pack)(arr)
-            from mplang.core.tensor import TensorType
-
-            unpacked = simp.runAt(0, crypto.unpack)(packed, TensorType.from_obj(arr))
+            packed = simp.runAt(0, builtin.pack)(arr)
+            unpacked = simp.runAt(0, builtin.unpack)(
+                packed, out_ty=TensorType.from_obj(arr)
+            )
             outs.append(unpacked)
         return tuple(outs)
 

--- a/tests/integration/test_symbols_roundtrip.py
+++ b/tests/integration/test_symbols_roundtrip.py
@@ -1,0 +1,127 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration: global symbols read -> compute -> write new global symbol.
+
+Flow:
+ 1. Spawn two HTTP runtimes via the shared fixture infrastructure.
+ 2. Use the client SDK to upload ``x`` only to party P0's global symbol table.
+ 3. Evaluate a function that reads ``x`` on P0, adds 1 on P0, sends the result to P1, and writes ``y`` from P1.
+ 4. Confirm the computation result is now held by P1 only.
+ 5. Use the client SDK to fetch ``y`` from the P1 runtime and verify ``y == x + 1``.
+
+This tests end-to-end interaction between:
+ - Global symbol CRUD endpoints
+ - ``builtin.read`` path using ``symbols://`` scheme
+ - Driver evaluation and fetch
+ - HttpExecutorClient helpers for symbol CRUD
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+import mplang
+import mplang.simp as simp
+from mplang.core.cluster import ClusterSpec, Device, Node, RuntimeInfo
+from mplang.core.dtype import DType
+from mplang.core.tensor import TensorType
+from mplang.frontend import builtin as fb
+from mplang.runtime.client import HttpExecutorClient
+
+pytest_plugins = ("tests.utils.server_fixtures",)
+
+
+@pytest.mark.parametrize("http_servers", [2], indirect=True)
+def test_global_symbol_roundtrip(http_servers):
+    node_ids = ["P0", "P1"]
+    node_addrs = dict(zip(node_ids, http_servers.addresses, strict=True))
+
+    # Cluster spec
+    nodes = {}
+    for nid, addr in node_addrs.items():
+        r = int(nid[1:])
+        nodes[f"node{r}"] = Node(
+            name=f"node{r}",
+            rank=r,
+            endpoint=addr,
+            runtime_info=RuntimeInfo(
+                version="test", platform="test", backends=["__all__"]
+            ),
+        )
+    local_devices = {
+        f"local_{n.rank}": Device(name=f"local_{n.rank}", kind="local", members=[n])
+        for n in nodes.values()
+    }
+    spu_device = Device(
+        name="SPU_0",
+        kind="SPU",
+        members=list(nodes.values()),
+        config={"protocol": "SEMI2K", "field": "FM64"},
+    )
+    spec = ClusterSpec(nodes=nodes, devices={**local_devices, "SPU_0": spu_device})
+    driver = mplang.Driver(spec)
+
+    arr = np.arange(5, dtype=np.int32)
+    tensor_meta = {"tensor": {"dtype": "I32", "shape": list(arr.shape)}}
+
+    async def upload_symbol(addr: str, symbol_name: str, data: np.ndarray) -> None:
+        client = HttpExecutorClient(addr)
+        try:
+            await client.create_global_symbol(symbol_name, data, tensor_meta)
+        finally:
+            await client.close()
+
+    # Seed only P0 with the initial value.
+    asyncio.run(upload_symbol(http_servers.addresses[0], "x", arr))
+
+    @mplang.function
+    def compute_chain():
+        ty = TensorType(DType.from_any(np.int32), (5,))
+        # P0 reads x from its local global symbol table.
+        x_p0 = simp.runAt(0, fb.read)(path="symbols://x", ty=ty)
+
+        # P0 computes x + 1.
+        def add_one(a):
+            import jax.numpy as jnp
+
+            return jnp.add(a, jnp.ones_like(a))
+
+        x_inc_p0 = simp.runAt(0, add_one)(x_p0)
+
+        # Transfer the result to P1 and write it out as symbols://y from P1.
+        x_p1 = simp.p2p(0, 1, x_inc_p0)
+        written = simp.runAt(1, fb.write)(x_p1, path="symbols://y")
+
+        return written
+
+    out = mplang.evaluate(driver, compute_chain)
+    fetched = mplang.fetch(driver, out)
+
+    # Only P1 should now hold the materialized value.
+    assert fetched[0] is None, "P0 should not retain the result after p2p transfer"
+    np.testing.assert_array_equal(fetched[1], arr + 1)
+
+    async def fetch_y_from_p1() -> np.ndarray:
+        client = HttpExecutorClient(http_servers.addresses[1])
+        try:
+            result = await client.get_global_symbol("y")
+            return np.asarray(result)
+        finally:
+            await client.close()
+
+    y_val = asyncio.run(fetch_y_from_p1())
+    np.testing.assert_array_equal(y_val, arr + 1)


### PR DESCRIPTION
Refactor packing and unpacking functions from the crypto module to the built-in module. Introduce a global symbol table with CRUD operations for managing symbols across sessions. Add unit tests and comments for clarity.