### PR TITLE
Add mock TEE kernel implementation and simulator updates

### DIFF
--- a/mplang/kernels/mock_tee.py
+++ b/mplang/kernels/mock_tee.py
@@ -43,7 +43,7 @@ def _quote_from_pk(pk: np.ndarray) -> NDArray[np.uint8]:
     return out
 
 
-@kernel_def("tee.quote")
+@kernel_def("mock_tee.quote")
 def _tee_quote(pfunc: PFunction, pk: object) -> NDArray[np.uint8]:
     pk = np.asarray(pk, dtype=np.uint8)
     # rng access ensures deterministic seeding per rank even if unused now
@@ -51,7 +51,7 @@ def _tee_quote(pfunc: PFunction, pk: object) -> NDArray[np.uint8]:
     return _quote_from_pk(pk)
 
 
-@kernel_def("tee.attest")
+@kernel_def("mock_tee.attest")
 def _tee_attest(pfunc: PFunction, quote: object) -> NDArray[np.uint8]:
     quote = np.asarray(quote, dtype=np.uint8)
     if quote.size != 33:

--- a/mplang/kernels/mock_tee.py
+++ b/mplang/kernels/mock_tee.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 
 import numpy as np
 from numpy.typing import NDArray
@@ -45,6 +46,10 @@ def _quote_from_pk(pk: np.ndarray) -> NDArray[np.uint8]:
 
 @kernel_def("mock_tee.quote")
 def _tee_quote(pfunc: PFunction, pk: object) -> NDArray[np.uint8]:
+    warnings.warn(
+        "Insecure mock TEE kernel 'mock_tee.quote' in use. NOT secure; for local testing only.",
+        stacklevel=3,
+    )
     pk = np.asarray(pk, dtype=np.uint8)
     # rng access ensures deterministic seeding per rank even if unused now
     _rng()
@@ -53,6 +58,10 @@ def _tee_quote(pfunc: PFunction, pk: object) -> NDArray[np.uint8]:
 
 @kernel_def("mock_tee.attest")
 def _tee_attest(pfunc: PFunction, quote: object) -> NDArray[np.uint8]:
+    warnings.warn(
+        "Insecure mock TEE kernel 'mock_tee.attest' in use. NOT secure; for local testing only.",
+        stacklevel=3,
+    )
     quote = np.asarray(quote, dtype=np.uint8)
     if quote.size != 33:
         raise ValueError("mock quote must be 33 bytes (1 header + 32 pk)")

--- a/mplang/runtime/simulation.py
+++ b/mplang/runtime/simulation.py
@@ -227,7 +227,8 @@ class Simulator(InterpContext):
                 None,
             )
             # Seed SPU once per runtime (idempotent logical requirement)
-            spu_meta = runtime.state.get("_spu", {})
+            # Use setdefault to both retrieve and create metadata dict in one step.
+            spu_meta = runtime.state.setdefault("_spu", {})
             if not spu_meta.get("inited", False):
                 link_ctx = self._spu_link_ctxs[rank]
                 seed_fn = PFunction(
@@ -239,7 +240,7 @@ class Simulator(InterpContext):
                     link=link_ctx,
                 )
                 ev.runtime.run_kernel(seed_fn, [])  # type: ignore[arg-type]
-                runtime.state.setdefault("_spu", {})["inited"] = True
+                spu_meta["inited"] = True
             pts_evaluators.append(ev)
 
         # Collect evaluation results from all parties

--- a/tests/ops/test_crypto_tee.py
+++ b/tests/ops/test_crypto_tee.py
@@ -74,7 +74,9 @@ def _demo_flow():
 
 
 def test_crypto_enc_dec_and_tee_quote_attest_roundtrip():
-    sim = mplang.Simulator.simple(3)
+    # Create simulator with TEE bindings using the new initial_bindings parameter
+    tee_bindings = {"tee.quote": "mock_tee.quote", "tee.attest": "mock_tee.attest"}
+    sim = mplang.Simulator.simple(3, op_bindings=tee_bindings)
     p0, p1 = mplang.evaluate(sim, _demo_flow)
     a = mplang.fetch(sim, p0)
     b = mplang.fetch(sim, p1)

--- a/tests/runtime/test_simulation.py
+++ b/tests/runtime/test_simulation.py
@@ -107,10 +107,10 @@ class TestSimulator:
     def test_simulator_creation(self):
         """Test Simulator creation."""
         sim = Simulator.simple(world_size=3)
-
         assert sim.world_size() == 3
         assert len(sim._comms) == 3
-        assert len(sim._evaluators) == 3
+        # persistent runtimes after refactor
+        assert len(sim._runtimes) == 3
 
         # Check that communicators are properly connected
         for i, comm in enumerate(sim._comms):

--- a/tutorials/3_device.py
+++ b/tutorials/3_device.py
@@ -100,7 +100,9 @@ def run_spu():
 def run_tee():
     print("-" * 10, "millionaire (TEE)", "-" * 10)
 
-    sim = mplang.Simulator(cluster_spec)
+    # TEE operations need explicit binding for security
+    tee_bindings = {"tee.quote": "mock_tee.quote", "tee.attest": "mock_tee.attest"}
+    sim = mplang.Simulator(cluster_spec, op_bindings=tee_bindings)
     x_p0, y_p1, z_t, r_p0 = mplang.evaluate(sim, millionaire, "TEE0")
     print("x_p0:", x_p0, mpd.fetch(sim, x_p0))
     print("y_p1:", y_p1, mpd.fetch(sim, y_p1))

--- a/tutorials/9_tee.py
+++ b/tutorials/9_tee.py
@@ -116,7 +116,9 @@ def millionaire_manual():
 
 def main():
     print("-" * 10, "TEE millionaire: device vs manual (end-to-end IR)", "-" * 10)
-    sim = Simulator(cluster_spec)
+    # Create simulator with TEE bindings
+    tee_bindings = {"tee.quote": "mock_tee.quote", "tee.attest": "mock_tee.attest"}
+    sim = Simulator(cluster_spec, op_bindings=tee_bindings)
 
     compiled_dev = mplang.compile(sim, millionaire_device)
     compiled_man = mplang.compile(sim, millionaire_manual)


### PR DESCRIPTION
Introduce a mock TEE kernel for local testing, update the simulator to support static operation bindings, and adjust tests and tutorials to demonstrate the new TEE bindings. A warning is added to indicate the mock kernel's insecure nature.