### PR TITLE
WIP: Refactor SecureBoost to use FHE vector operations for batch feature-wise bucket sums

### DIFF
--- a/examples/xgboost/bench_fhe_hist.py
+++ b/examples/xgboost/bench_fhe_hist.py
@@ -295,7 +295,6 @@ def _bench_once(
                     h_ct,
                     subgroup_map_pp,
                     pp_idx[i],
-                    pub_ctx_pp,
                     k,
                     t,
                     rank=pp,

--- a/examples/xgboost/sgb_test.py
+++ b/examples/xgboost/sgb_test.py
@@ -391,8 +391,6 @@ def _run_pp_fhe_cumulative_once(X_parts, y_jax, all_party_ids_list, params):
     qg = mp.run_jax_at(ap_id, lambda a: a[:, 0].astype(jnp.int64), Q)
     qh = mp.run_jax_at(ap_id, lambda a: a[:, 1].astype(jnp.int64), Q)
     priv_ctx, pub_ctx, _ = mp.run_at(ap_id, fhe.keygen, scheme="BFV")
-    # Move pub_ctx to PP for local encryption
-    pub_ctx_pp = mp.p2p(ap_id, pp_id, pub_ctx)
     g_ct = mp.run_at(ap_id, fhe.encrypt, qg, pub_ctx)
     h_ct = mp.run_at(ap_id, fhe.encrypt, qh, pub_ctx)
 
@@ -407,7 +405,6 @@ def _run_pp_fhe_cumulative_once(X_parts, y_jax, all_party_ids_list, params):
         h_ct,
         subgroup_map,
         bin_idx_pp,
-        pub_ctx_pp,
         params["max_bin"],
         1,
         rank=pp_id,
@@ -536,8 +533,6 @@ def run_bucket_sum_2_groups():
 
     # Keygen (BFV)
     priv_ctx, pub_ctx, _ = mp.run_at(0, fhe.keygen, scheme="BFV")
-    # Move pub_ctx to PP(1) for local encryption
-    pub_ctx_pp = mp.p2p(0, 1, pub_ctx)
 
     # Prepare g/h integer vectors at AP
     m1 = mp.run_jax_at(0, lambda x: x, m1_np)
@@ -558,7 +553,6 @@ def run_bucket_sum_2_groups():
         h_ct,
         subgroup_map,
         order_map,
-        pub_ctx_pp,
         bucket_num,
         group_size,
         rank=1,
@@ -625,8 +619,6 @@ def run_bucket_sum_3_groups():
 
     # Keygen (BFV)
     priv_ctx, pub_ctx, _ = mp.run_at(0, fhe.keygen, scheme="BFV")
-    # Move pub_ctx to PP(1) for local encryption
-    pub_ctx_pp = mp.p2p(0, 1, pub_ctx)
 
     # Prepare g/h integer vectors at AP
     m1 = mp.run_jax_at(0, lambda x: x, m1_np)
@@ -647,7 +639,6 @@ def run_bucket_sum_3_groups():
         h_ct,
         subgroup_map,
         order_map,
-        pub_ctx_pp,
         bucket_num,
         group_size,
         rank=1,

--- a/mplang/kernels/fhe.py
+++ b/mplang/kernels/fhe.py
@@ -25,6 +25,7 @@ import tenseal as ts
 
 from mplang.core import DType, PFunction, TensorLike
 from mplang.kernels.base import kernel_def
+from mplang.kernels.value import TensorValue
 
 
 class FHEContext:
@@ -337,13 +338,14 @@ def _fhe_decrypt(pfunc: PFunction, ciphertext: CipherText, context: FHEContext) 
 
         # Restore original shape
         if ciphertext.semantic_shape == ():
-            # Was a scalar, extract single value
-            result = decrypted_np[0:1].reshape(())
+            # Was a scalar, extract single value and wrap as TensorValue scalar
+            result_np = decrypted_np[0:1].reshape(())
         else:
             # Keep as vector
-            result = decrypted_np
+            result_np = decrypted_np
 
-        return (result,)
+        # Always return TensorValue to be compatible with downstream StableHLO kernels
+        return (TensorValue(np.asarray(result_np)),)
 
     except Exception as e:
         raise RuntimeError(f"FHE vector decryption failed: {e}") from e


### PR DESCRIPTION
- Updated `sgb.py` to replace PHE operations with FHE vector operations in the `batch_feature_wise_bucket_sum` function.
- Enhanced comments and documentation to clarify the data flow and security model for the new FHE implementation.
- Modified the `build_tree` function to accommodate changes in the input parameters and processing of encrypted gradient and Hessian values.
- Added quantization helpers for fixed-point representation of GH values.
- Updated tests in `sgb_test.py` to validate the new FHE-based cumulative GH calculations and ensure correctness against plaintext results.
- Improved debugging output in test functions to facilitate easier tracing of values during execution.