### PR TITLE
run jax support dynamic shape

### DIFF
--- a/mplang/backends/tensor_impl.py
+++ b/mplang/backends/tensor_impl.py
@@ -324,24 +324,224 @@ def elementwise_impl(interpreter: Interpreter, op: Operation, *args: Value) -> A
         return _wrap(results)
 
 
-# Global cache for compiled StableHLO executables
-_STABLEHLO_CACHE: dict[str, Any] = {}
+# =============================================================================
+# IREE Runtime Support
+# =============================================================================
+
+# Check if IREE is available (actual imports are done lazily in _run_jax_with_iree)
+try:
+    import importlib.util
+
+    IREE_AVAILABLE = (
+        importlib.util.find_spec("iree.compiler") is not None
+        and importlib.util.find_spec("iree.runtime") is not None
+    )
+except (ImportError, ValueError):
+    IREE_AVAILABLE = False
+
+# Global cache for IREE compiled flatbuffers
+# Key: SHA256 hash of stablehlo_code
+# Value: compiled flatbuffer bytes
+_IREE_CACHE: dict[str, Any] = {}
 
 
-@tensor.run_jax_p.def_impl
-def run_jax_impl(
-    interpreter: Interpreter, op: Operation, *args: TensorValue
+def _create_iree_context() -> Any:
+    """Create a new IREE runtime context.
+
+    Creates a fresh context for each execution to avoid module name conflicts
+    when multiple run_jax calls are made with different functions.
+
+    Note: This function should only be called when IREE is available.
+    The caller is responsible for checking IREE_AVAILABLE before calling.
+
+    Returns:
+        IREE SystemContext instance
+
+    Raises:
+        RuntimeError: If IREE context initialization fails
+    """
+    try:
+        import iree.runtime
+
+        config = iree.runtime.Config("local-task")
+        ctx = iree.runtime.SystemContext(config=config)
+        return ctx
+
+    except Exception as e:
+        logger.error(f"Failed to create IREE context: {e}")
+        raise RuntimeError(f"IREE context creation failed: {e}") from e
+
+
+def _run_jax_with_iree(
+    interpreter: Interpreter,
+    op: Operation,
+    args: tuple[TensorValue, ...],
+    stablehlo_code: str,
+    t0: float,
 ) -> TensorValue | list[TensorValue]:
-    """Execute JAX function."""
-    t0 = time.time()
+    """Execute JAX function using IREE runtime.
 
-    # Execute via StableHLO
-    stablehlo_code = op.attrs.get("stablehlo_code")
-    if stablehlo_code is None:
-        raise NotImplementedError(
-            "run_jax execution requires 'stablehlo_code' attribute"
+    IREE supports jax.uses_shape_polymorphism, making it suitable for dynamic shapes.
+
+    Args:
+        interpreter: The interpreter instance
+        op: The operation being executed
+        args: Input tensor values
+        stablehlo_code: StableHLO MLIR code
+        t0: Start time for profiling
+
+    Returns:
+        Output tensor value(s)
+    """
+    if not IREE_AVAILABLE:
+        raise RuntimeError(
+            "IREE execution requested but IREE is not installed. "
+            "Install IREE with: pip install iree-compiler iree-runtime"
         )
 
+    import iree.compiler
+    import iree.runtime
+    from iree.compiler import InputType
+
+    # Prepare inputs: unwrap TensorValue to numpy arrays
+    t1 = time.time()
+    numpy_args = []
+    for i, arg in enumerate(args):
+        if isinstance(arg, TensorValue):
+            numpy_args.append(arg.unwrap())
+        else:
+            numpy_args.append(np.asarray(arg))
+
+        # Cast to expected dtype if needed
+        if i < len(op.inputs):
+            input_type = op.inputs[i].type
+            if isinstance(input_type, elt.TensorType):
+                dtype = dtypes.to_jax(cast(elt.ScalarType, input_type.element_type))
+                if (
+                    dtype is not None
+                    and isinstance(numpy_args[i], np.ndarray)
+                    and numpy_args[i].dtype != dtype
+                ):
+                    numpy_args[i] = numpy_args[i].astype(dtype)
+
+    # Handle JAX's unused parameter elimination via arg_keep_map
+    arg_keep_map = op.attrs.get("arg_keep_map")
+    if arg_keep_map is not None:
+        # Filter out arguments that were eliminated by JAX during compilation
+        numpy_args = [numpy_args[i] for i in arg_keep_map]
+
+    t2 = time.time()
+
+    # Use SHA256 of code as cache key
+    code_hash = hashlib.sha256(stablehlo_code.encode("utf-8")).hexdigest()
+
+    # Compile with IREE (cache flatbuffer, create new context for each execution)
+    if code_hash in _IREE_CACHE:
+        flatbuffer = _IREE_CACHE[code_hash]
+        t3 = t2  # No compilation time
+    else:
+        try:
+            # Use CPU backend for stability (avoids CUDA context issues)
+            target_backend = "llvm-cpu"
+
+            # Compile with full type preservation:
+            # 1. Disable all type demotions (f64->f32, i64->i32) to preserve original types
+            # 2. Use system linker instead of embedded linker to support f64 math functions
+            #    (embedded linker cannot link system libm which is needed for exp, log, etc.)
+            # See: https://iree.dev/reference/mlir-passes/InputConversion/
+            compile_args = [
+                "--iree-llvmcpu-target-cpu=host",
+                # Disable type demotions
+                "--iree-input-demote-f64-to-f32=false",
+                "--iree-input-demote-i64-to-i32=false",
+                # Use system linker for libm support
+                "--iree-llvmcpu-link-embedded=false",
+            ]
+
+            flatbuffer = iree.compiler.compile_str(
+                stablehlo_code,
+                target_backends=[target_backend],
+                input_type=InputType.STABLEHLO,
+                extra_args=compile_args,
+            )
+
+            # Cache the flatbuffer (not the module, since context is not shared)
+            _IREE_CACHE[code_hash] = flatbuffer
+
+            t3 = time.time()
+
+        except Exception as e:
+            raise RuntimeError(f"IREE compilation failed: {e}") from e
+
+    # Create a new IREE context for each execution to avoid module name conflicts
+    ctx = _create_iree_context()
+
+    # Load the compiled module into the new context
+    vm_module = iree.runtime.VmModule.copy_buffer(ctx.instance, flatbuffer)
+    ctx.add_vm_module(vm_module)
+
+    # Get module name from vm_module
+    module_name = vm_module.name
+    if module_name not in ctx.modules:
+        raise RuntimeError(
+            f"Module '{module_name}' not found in IREE context. "
+            f"Available modules: {list(ctx.modules.keys())}"
+        )
+
+    module = ctx.modules[module_name]
+
+    # Execute the function
+    result = module.main(*numpy_args)
+    t4 = time.time()
+
+    # Convert result to TensorValue
+    if isinstance(result, (list, tuple)):
+        flat = [_wrap(np.asarray(r)) for r in result]
+    else:
+        flat = [_wrap(np.asarray(result))]
+
+    t5 = time.time()
+
+    # Profiling
+    if interpreter.tracer:
+        p = interpreter.tracer
+        p.log_custom_event("IREE Prep", t0, t1, cat="iree")
+        p.log_custom_event("IREE Cast", t1, t2, cat="iree")
+        p.log_custom_event("IREE Compile", t2, t3, cat="iree")
+        p.log_custom_event("IREE Exec", t3, t4, cat="iree")
+        p.log_custom_event("IREE Wrap", t4, t5, cat="iree")
+
+    # Return single value or list based on output count
+    if len(op.outputs) == 1 and len(flat) == 1:
+        return flat[0]
+    return flat
+
+
+# Global cache for compiled StableHLO executables
+_XLA_CACHE: dict[str, Any] = {}
+
+
+def _run_jax_with_xla(
+    interpreter: Interpreter,
+    op: Operation,
+    args: tuple[TensorValue, ...],
+    stablehlo_code: str,
+    t0: float,
+) -> TensorValue | list[TensorValue]:
+    """Execute JAX function using JAX XLA compilation.
+
+    This is the original execution method using JAX's XLA compiler.
+
+    Args:
+        interpreter: The interpreter instance
+        op: The operation being executed
+        args: Input tensor values
+        stablehlo_code: StableHLO MLIR code
+        t0: Start time for profiling
+
+    Returns:
+        Output tensor value(s)
+    """
     # Compile StableHLO
     client = jxt.backend.get_backend()
 
@@ -349,8 +549,8 @@ def run_jax_impl(
     # Note: We assume compile_options are constant (num_replicas=1, num_partitions=1)
     code_hash = hashlib.sha256(stablehlo_code.encode("utf-8")).hexdigest()
 
-    if code_hash in _STABLEHLO_CACHE:
-        compiled = _STABLEHLO_CACHE[code_hash]
+    if code_hash in _XLA_CACHE:
+        compiled = _XLA_CACHE[code_hash]
     else:
         compile_options = compiler.get_compile_options(num_replicas=1, num_partitions=1)
 
@@ -388,7 +588,7 @@ def run_jax_impl(
             except Exception as e:
                 raise RuntimeError(f"StableHLO compile failed: {e}") from e
 
-        _STABLEHLO_CACHE[code_hash] = compiled
+        _XLA_CACHE[code_hash] = compiled
 
     # Cast inputs to expected types (Boundary Type Guard)
     # This allows users to pass Python ints/floats to functions expecting f32/i32
@@ -467,6 +667,39 @@ def run_jax_impl(
         return flat
     except Exception as e:
         raise RuntimeError(f"StableHLO execute failed: {e}") from e
+
+
+@tensor.run_jax_p.def_impl
+def run_jax_impl(
+    interpreter: Interpreter, op: Operation, *args: TensorValue
+) -> TensorValue | list[TensorValue]:
+    """Execute JAX function.
+
+    This is the entry point for JAX function execution.
+
+    Execution strategy:
+    - If IREE is available: use IREE runtime (supports jax.uses_shape_polymorphism for dynamic shapes)
+    - Otherwise: use JAX XLA compilation
+
+    IREE is preferred because it supports dynamic shapes via shape polymorphism,
+    while XLA requires static shapes.
+    """
+    t0 = time.time()
+
+    # Get StableHLO code
+    stablehlo_code = op.attrs.get("stablehlo_code")
+    if stablehlo_code is None:
+        raise NotImplementedError(
+            "run_jax execution requires 'stablehlo_code' attribute"
+        )
+
+    backend = op.attrs.get("backend", "iree")
+
+    # Use IREE if available (supports dynamic shapes), otherwise use XLA
+    if IREE_AVAILABLE and backend == "iree":
+        return _run_jax_with_iree(interpreter, op, args, stablehlo_code, t0)
+    else:
+        return _run_jax_with_xla(interpreter, op, args, stablehlo_code, t0)
 
 
 @tensor.gather_p.def_impl

--- a/mplang/backends/tensor_impl.py
+++ b/mplang/backends/tensor_impl.py
@@ -693,7 +693,9 @@ def run_jax_impl(
             "run_jax execution requires 'stablehlo_code' attribute"
         )
 
-    backend = op.attrs.get("backend", "iree")
+    backend = op.attrs.get("backend", "")
+    if backend == "" or backend == "auto":
+        backend = "xla"
 
     # Use IREE if available (supports dynamic shapes), otherwise use XLA
     if IREE_AVAILABLE and backend == "iree":

--- a/mplang/dialects/tensor.py
+++ b/mplang/dialects/tensor.py
@@ -129,15 +129,6 @@ def get_run_jax_compilation(compilation_id: str) -> RunJaxCompilation:
         ) from exc
 
 
-# Configure JAX to limit the number of location attributes in exported MLIR.
-# This reduces the verbosity of StableHLO output and:
-# 1. Makes the generated code more readable
-# 2. Reduces memory usage for large models
-# 3. Avoids excessive location information that traces through the entire call stack
-# Setting to 0 disables detailed trace locations while preserving essential source info.
-jax.config.update("jax_traceback_in_locations_limit", 0)
-
-
 def mark_symbolic_shapes(
     fn: Callable | None = None, *, in_shapes: Sequence[Sequence[str | None]]
 ) -> Callable:
@@ -154,7 +145,6 @@ def mark_symbolic_shapes(
                   - None: Use static shape (don't mark)
                   - List/tuple of dimensions: Each dimension can be:
                     - str: Symbolic dimension name (e.g., "batch", "seq_len")
-                    - int: Static dimension size
                     - None: Static (will be inferred from actual input)
 
     Returns:
@@ -217,7 +207,8 @@ def _get_symbolic_name(
             raise ValueError(f"Symbolic shape name must be a string, got {type(name)}")
         return name
 
-    # builtin symbolic shape name
+    # We use "n_rows" instead of generic pattern like f"arg_{obj_idx}_dim_{dim_idx}"
+    # because our common use case is representing unknown row count in tabular data
     return "n_rows"
 
 
@@ -233,6 +224,7 @@ def _make_placeholders(
         if name in symbol_map:
             return symbol_map[name]
         symbolics = jax.export.symbolic_shape(name, scope=symbol_scope)
+        symbol_map[name] = symbolics[0]
         return symbolics[0]
 
     placeholders: list[jax.ShapeDtypeStruct] = []
@@ -301,9 +293,13 @@ def _compile_run_jax(
     def wrapped_fn(*args: Any) -> Any:
         return normalized_fn(list(args))
 
+    # Tip: Use `jax.config.update("jax_traceback_in_locations_limit", 0)` to reduce location information
+    # in MLIR output. This disables JAX traceback locations, removing verbose source location
+    # annotations (e.g., #loc = #loc1) from the generated MLIR, which makes the output more
+    # readable and reduces serialization overhead.
     jitted = jax.jit(wrapped_fn)
     exported = jax.export.export(jitted)(*placeholders)
-    stablehlo_text = exported.mlir_module()
+    stablehlo_text = str(exported.mlir_module())
 
     # Handle JAX's unused parameter elimination
     arg_keep_map: list[int] | None = None

--- a/mplang/dialects/tensor.py
+++ b/mplang/dialects/tensor.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 import base64
 import functools
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from itertools import count
 from typing import Any, cast
@@ -56,7 +56,6 @@ from weakref import WeakKeyDictionary
 
 import jax
 import numpy as np
-from jax import ShapeDtypeStruct
 from jax.tree_util import PyTreeDef, tree_flatten
 
 import mplang.edsl as el
@@ -82,6 +81,7 @@ class RunJaxCompilation:
     out_tree: PyTreeDef  # type: ignore
     output_types: list[elt.BaseType]
     arg_keep_map: list[int] | None = None
+    has_dynamic_shape: bool = False
 
 
 _RUN_JAX_REGISTRY: dict[str, RunJaxCompilation] = {}
@@ -103,41 +103,10 @@ def _numpy_dtype_to_scalar(dtype: Any) -> elt.ScalarType:
     return dtypes.from_dtype(dtype)
 
 
-def _tensor_type_to_placeholder(
-    tensor_type: elt.TensorType | elt.ScalarType,
-) -> ShapeDtypeStruct:
-    if isinstance(tensor_type, elt.ScalarType):
-        # Treat scalar as rank-0 tensor
-        dtype = _scalar_to_numpy_dtype(tensor_type)
-        return ShapeDtypeStruct((), dtype)
-
-    normalized_shape: list[int] = []
-    for idx, dim in enumerate(tensor_type.shape):
-        if dim is None:
-            raise TypeError(
-                f"tensor.run_jax argument dimension {idx} is None; "
-                "please provide a static dimension."
-            )
-        if dim == -1:
-            raise TypeError(
-                "tensor.run_jax does not yet support dynamic (-1) dimensions"
-            )
-        if dim <= 0 and dim != 0:
-            raise ValueError(f"Invalid tensor dimension {dim}")
-        normalized_shape.append(dim)
-    # element_type must be ScalarType for conversion to numpy dtype
-    if not isinstance(tensor_type.element_type, elt.ScalarType):
-        raise TypeError(
-            f"Expected ScalarType element, got {type(tensor_type.element_type)}"
-        )
-    dtype = _scalar_to_numpy_dtype(tensor_type.element_type)
-    return ShapeDtypeStruct(tuple(normalized_shape), dtype)
-
-
 def _out_info_to_edsl(out_info: Any) -> elt.TensorType:
     scalar = _numpy_dtype_to_scalar(out_info.dtype)
-    shape = tuple(out_info.shape)
-    return elt.TensorType(scalar, shape)
+    shape = [dim if isinstance(dim, int) else -1 for dim in out_info.shape]
+    return elt.TensorType(scalar, tuple(shape))
 
 
 def _register_compilation(compilation: RunJaxCompilation) -> str:
@@ -160,14 +129,154 @@ def get_run_jax_compilation(compilation_id: str) -> RunJaxCompilation:
         ) from exc
 
 
+# Configure JAX to limit the number of location attributes in exported MLIR.
+# This reduces the verbosity of StableHLO output and:
+# 1. Makes the generated code more readable
+# 2. Reduces memory usage for large models
+# 3. Avoids excessive location information that traces through the entire call stack
+# Setting to 0 disables detailed trace locations while preserving essential source info.
+jax.config.update("jax_traceback_in_locations_limit", 0)
+
+
+def mark_symbolic_shapes(
+    fn: Callable | None = None, *, in_shapes: Sequence[Sequence[str | None]]
+) -> Callable:
+    """Mark symbolic shapes for function parameters.
+
+    This function can be used as a decorator or applied directly to a function.
+    It marks the input parameters with symbolic shape specifications where
+    dynamic dimensions are represented by strings and None indicates static shapes.
+
+    Args:
+        fn: Function to mark (when used directly, not as decorator)
+        in_shapes: List of shape specifications for each parameter.
+                  Each element can be:
+                  - None: Use static shape (don't mark)
+                  - List/tuple of dimensions: Each dimension can be:
+                    - str: Symbolic dimension name (e.g., "batch", "seq_len")
+                    - int: Static dimension size
+                    - None: Static (will be inferred from actual input)
+
+    Returns:
+        The function with symbolic shapes marked
+
+    Examples:
+        # As decorator
+        @mark_symbolic_shapes(in_shapes=[("batch", "seq_len"), ("seq_len", "hidden")])
+        def matmul(x, y):
+            return jnp.matmul(x, y)
+
+        # Applied directly
+        def add(x, y):
+            return x + y
+        add = mark_symbolic_shapes(add, in_shapes=[("batch",), ("batch",)])
+    """
+
+    def decorator(func: Callable) -> Callable:
+        # Store symbolic shapes information on the function
+        cast(Any, func)._symbolic_shapes = in_shapes
+        return func
+
+    if fn is not None:
+        # Direct application mode
+        return decorator(fn)
+    else:
+        # Decorator mode
+        return decorator
+
+
+def _get_symbolic_shapes(fn: Callable) -> Sequence[Sequence[str | None]] | None:
+    """Get symbolic shapes information from a marked function.
+
+    Args:
+        fn: Function that was marked with mark_symbolic_shapes
+
+    Returns:
+        Dictionary with symbolic shapes information or None if not marked
+    """
+    if hasattr(fn, "_symbolic_shapes"):
+        return cast(Sequence[Sequence[str | None]], fn._symbolic_shapes)  # type: ignore[attr-defined]
+
+    # Also check the original function if fn is a wrapper
+    if hasattr(fn, "__wrapped__"):
+        return _get_symbolic_shapes(fn.__wrapped__)
+
+    return None
+
+
+def _get_symbolic_name(
+    symbolic_shapes: Sequence[Sequence[str | None]] | None, obj_idx: int, dim_idx: int
+) -> str:
+    if (
+        symbolic_shapes is not None
+        and obj_idx < len(symbolic_shapes)
+        and dim_idx < len(symbolic_shapes[obj_idx])
+    ):
+        name = symbolic_shapes[obj_idx][dim_idx]
+        if not isinstance(name, str):
+            raise ValueError(f"Symbolic shape name must be a string, got {type(name)}")
+        return name
+
+    # builtin symbolic shape name
+    return "n_rows"
+
+
+def _make_placeholders(
+    variables: list[el.Object], symbolic_shapes: Sequence[Sequence[str | None]] | None
+) -> list[jax.ShapeDtypeStruct]:
+    # Build symbolic shapes and placeholders
+    symbol_scope = jax.export.SymbolicScope()
+    # Maps symbol name to SymbolicDimension
+    symbol_map: dict[str, Any] = {}
+
+    def _make_symbol(name: str) -> Any:
+        if name in symbol_map:
+            return symbol_map[name]
+        symbolics = jax.export.symbolic_shape(name, scope=symbol_scope)
+        return symbolics[0]
+
+    placeholders: list[jax.ShapeDtypeStruct] = []
+    for obj_idx, obj in enumerate(variables):
+        if not isinstance(obj.type, (elt.TensorType, elt.ScalarType)):
+            raise TypeError(f"run_jax only supports Tensors/Scalars, got {obj.type}")
+        if isinstance(obj.type, elt.ScalarType):
+            dtype = _scalar_to_numpy_dtype(obj.type)
+            placeholders.append(jax.ShapeDtypeStruct((), dtype))
+        else:
+            # element_type must be ScalarType for conversion to numpy dtype
+            if not isinstance(obj.type.element_type, elt.ScalarType):
+                raise TypeError(
+                    f"Expected ScalarType element, got {type(obj.type.element_type)}"
+                )
+            obj_shape = []
+            for idx, dim in enumerate(obj.type.shape):
+                if dim is None:
+                    raise TypeError(
+                        f"tensor.run_jax argument dimension {idx} is None; "
+                        "please provide a static dimension."
+                    )
+                elif dim < -1 or dim == 0:
+                    raise ValueError(f"Invalid tensor dimension {dim}")
+                if dim == -1:
+                    name = _get_symbolic_name(symbolic_shapes, obj_idx, idx)
+                    symbol = _make_symbol(name)
+                    obj_shape.append(symbol)
+                else:
+                    obj_shape.append(dim)
+            dtype = _scalar_to_numpy_dtype(obj.type.element_type)
+            placeholders.append(jax.ShapeDtypeStruct(obj_shape, dtype))
+
+    return placeholders
+
+
 def _compile_run_jax(
     fn: Callable[..., Any],
     normalized_fn: Callable[..., Any],
-    placeholders: list[ShapeDtypeStruct],
+    placeholders: list[jax.ShapeDtypeStruct],
 ) -> tuple[RunJaxCompilation, str]:
     """Compile JAX function to StableHLO MLIR.
 
-    Pipeline: jit → lower → StableHLO MLIR
+    Pipeline: jit → export → StableHLO MLIR
 
     Args:
         fn: Original JAX function
@@ -177,37 +286,51 @@ def _compile_run_jax(
     Returns:
         Tuple of (compilation record, compilation_id)
     """
-    jitted = jax.jit(normalized_fn)
-    lowered = jitted.lower(placeholders)
-    stablehlo_text = str(lowered.compiler_ir("stablehlo"))
+
+    # Calculate has_dynamic_shape from placeholders
+    # Check if any placeholder has symbolic dimensions (i.e., non-concrete shape)
+    has_dynamic_shape = any(
+        not all(isinstance(dim, int) for dim in placeholder.shape)
+        for placeholder in placeholders
+    )
+
+    # Wrap normalized_fn to collect JAX's individual args into a list
+    # This is needed because:
+    # - normalized_fn expects: normalized([arg1, arg2, ...])
+    # - But JAX export calls: wrapper_fn(arg1, arg2, ...)
+    def wrapped_fn(*args: Any) -> Any:
+        return normalized_fn(list(args))
+
+    jitted = jax.jit(wrapped_fn)
+    exported = jax.export.export(jitted)(*placeholders)
+    stablehlo_text = exported.mlir_module()
 
     # Handle JAX's unused parameter elimination
     arg_keep_map: list[int] | None = None
     try:
-        compile_args = lowered._lowering.compile_args
-        kept_var_idx = compile_args["kept_var_idx"]
-        kept_indices = sorted(kept_var_idx)
-        if len(kept_indices) < len(placeholders):
-            arg_keep_map = kept_indices
-    except (AttributeError, KeyError, TypeError) as e:
+        kept_var_idx = exported.module_kept_var_idx
+        if len(kept_var_idx) < len(placeholders):
+            arg_keep_map = list(kept_var_idx)
+    except (AttributeError, TypeError) as e:
         raise RuntimeError(
-            f"Cannot access JAX's kept_var_idx for unused parameter handling. "
+            f"Cannot access JAX's module_kept_var_idx for unused parameter handling. "
             f"JAX may have optimized away unused parameters. Error: {e}"
         ) from e
 
     # Convert output info to EDSL types
     output_types: list[elt.BaseType]
-    if isinstance(lowered.out_info, tuple):
-        output_types = [_out_info_to_edsl(info) for info in lowered.out_info]
+    if isinstance(exported.out_avals, tuple):
+        output_types = [_out_info_to_edsl(aval) for aval in exported.out_avals]
     else:
-        output_types = [_out_info_to_edsl(lowered.out_info)]
+        output_types = [_out_info_to_edsl(exported.out_avals)]
 
     compilation = RunJaxCompilation(
         fn=fn,
         stablehlo=stablehlo_text,
-        out_tree=lowered.out_tree,
+        out_tree=exported.out_tree,
         output_types=output_types,
         arg_keep_map=arg_keep_map,
+        has_dynamic_shape=has_dynamic_shape,
     )
     compilation_id = _register_compilation(compilation)
     return compilation, compilation_id
@@ -238,19 +361,14 @@ def _run_jax_trace(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
 
     normalized_fn, variables = normalize_fn(fn, args, kwargs, _is_trace_object)
 
-    # Convert TraceObjects to JAX placeholders for compilation
-    placeholders: list[ShapeDtypeStruct] = []
-    for var in variables:
-        if not isinstance(var, el.TraceObject):
-            raise TypeError(f"Expected TraceObject, got {type(var)}")
-        if not isinstance(var.type, (elt.TensorType, elt.ScalarType)):
-            raise TypeError(f"run_jax only supports Tensors/Scalars, got {var.type}")
-        placeholders.append(_tensor_type_to_placeholder(var.type))
+    symbolic_shapes = _get_symbolic_shapes(fn)
+    placeholders = _make_placeholders(variables, symbolic_shapes)
 
     # Compile to StableHLO
     compilation, text_ref = _compile_run_jax(fn, normalized_fn, placeholders)
 
     # Emit graph operation
+    backend = "iree" if compilation.has_dynamic_shape else "auto"
     input_values = [var._graph_value for var in variables]
     result_values = tracer.graph.add_op(
         opcode="tensor.run_jax",
@@ -261,6 +379,7 @@ def _run_jax_trace(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
             "text_ref": text_ref,
             "stablehlo_code": compilation.stablehlo,
             "arg_keep_map": compilation.arg_keep_map,
+            "backend": backend,
         },
     )
 
@@ -1162,6 +1281,7 @@ __all__ = [
     "gather_p",
     "get_run_jax_compilation",
     "jax_fn",
+    "mark_symbolic_shapes",
     "reshape",
     "reshape_p",
     "run_jax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     "cryptography>=43.0.0",
     "coincurve>=20.0.0",
     "PyYAML>=6.0",
+    # IREE for dynamic shape support
+    "iree-compiler",
+    "iree-runtime",
 ]
 
 [project.scripts]

--- a/tests/backends/test_tensor_impl.py
+++ b/tests/backends/test_tensor_impl.py
@@ -75,7 +75,7 @@ def test_tensor_run_dynamic_shape():
     # jax.config.update("jax_enable_x64", True)
 
     # Phase 1: Define function with type annotations
-    @tensor.mark_symbolic_shapes(in_shapes=[("rows")])
+    @tensor.mark_symbolic_shapes(in_shapes=[("rows",)])
     def square(x: jnp.ndarray):
         return jnp.square(x)
 

--- a/tests/backends/test_tensor_impl.py
+++ b/tests/backends/test_tensor_impl.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import jax.numpy as jnp
 import numpy as np
 
@@ -49,6 +50,70 @@ def test_tensor_ops_e2e():
     np.testing.assert_allclose(result.runtime_obj.unwrap(), expected)
 
 
+def test_tensor_run_dynamic_shape():
+    """Test tracing with TensorType to get compiled graph.
+
+    This test requires IREE to be installed because dynamic shapes
+    (uses_shape_polymorphism) are only supported by IREE, not by JAX XLA.
+    """
+
+    # Check if IREE is available
+    try:
+        import iree.compiler  # noqa: F401
+        import iree.runtime  # noqa: F401
+    except ImportError:
+        import pytest
+
+        pytest.skip("IREE not installed, skipping dynamic shape test")
+
+    import jax.numpy as jnp
+
+    import mplang as mp
+    import mplang.edsl as el
+    import mplang.edsl.typing as elt
+
+    # jax.config.update("jax_enable_x64", True)
+
+    # Phase 1: Define function with type annotations
+    @tensor.mark_symbolic_shapes(in_shapes=[("rows")])
+    def square(x: jnp.ndarray):
+        return jnp.square(x)
+
+    def exec(x):
+        return tensor.run_jax(square, x)
+
+    tracer = el.Tracer()
+    tensor_type = elt.TensorType(elt.f32, (-1,))
+    x_obj = tracer._new_arg(tensor_type)
+    traced_fn = mp.compile(exec, x_obj)
+
+    assert "tensor<?xf32>" in traced_fn.graph.to_string(verbose=True)
+
+    # Phase 2: Execute with various test inputs to verify run_jax_impl handles dynamic shapes
+    from mplang.runtime.interpreter import Interpreter
+
+    # Create interpreter context
+    interp = Interpreter()
+
+    test_cases = [
+        np.array([1.0, 2.0, 3.0], dtype=np.float32),  # Size 3
+        np.array([0.5, -1.5, 2.0, 3.5], dtype=np.float32),  # Size 4
+        np.arange(10, dtype=np.float32),  # Size 10
+    ]
+
+    for input_data in test_cases:
+        # Execute the compiled function with actual data using mp.evaluate
+        result = mp.evaluate(traced_fn, input_data, context=interp)
+
+        # Verify the result
+        expected = np.square(input_data)
+        np.testing.assert_allclose(result.runtime_obj.unwrap(), expected)
+
+        # Verify output is TensorValue
+        assert hasattr(result, "runtime_obj")
+        assert hasattr(result.runtime_obj, "unwrap")
+
+
 def test_tensor_elementwise():
     """Test elementwise operation."""
 
@@ -65,7 +130,7 @@ def test_tensor_elementwise():
 
     result = workload()
     # elementwise_impl returns TensorValue wrapping object array, unwrap it first
-    result_val = result.runtime_obj
+    result_val = result.runtime_obj  # type: ignore
     if hasattr(result_val, "unwrap"):
         result_val = result_val.unwrap()
 
@@ -94,7 +159,7 @@ def test_tensor_elementwise_broadcasting():
 
     result = workload()
     # elementwise_impl returns TensorValue wrapping object array, unwrap it first
-    result_val = result.runtime_obj
+    result_val = result.runtime_obj  # type: ignore
     if hasattr(result_val, "unwrap"):
         result_val = result_val.unwrap()
 
@@ -122,8 +187,8 @@ def test_tensor_elementwise_scalar():
 
     result = workload()
     # Result should be a 0-d array or scalar
-    assert np.ndim(result.runtime_obj.unwrap()) == 0
-    assert result.runtime_obj.unwrap() == 200.0
+    assert np.ndim(result.runtime_obj.unwrap()) == 0  # type: ignore
+    assert result.runtime_obj.unwrap() == 200.0  # type: ignore
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,9 @@ jax.config.update("jax_enable_compilation_cache", False)
 # Enable x64 to match numpy's default integer precision
 jax.config.update("jax_enable_x64", True)
 
+# reduce location information
+jax.config.update("jax_traceback_in_locations_limit", 0)
+
 # Suppress known TEE mock warnings in tests (expected for local testing)
 warnings.filterwarnings("ignore", message=".*Insecure mock TEE.*")
 

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -36,8 +36,8 @@ def _complex_body(a, b):
 
 
 def test_func_call_emits_region():
-    x = InterpObject(np.array(1.0), elt.Tensor[elt.f32, ()])
-    y = InterpObject(np.array(3.0), elt.Tensor[elt.f32, ()])
+    x = InterpObject(np.array(1.0), elt.Tensor[elt.f32, ()])  # type: ignore
+    y = InterpObject(np.array(3.0), elt.Tensor[elt.f32, ()])  # type: ignore
 
     def wrapper(a, b):
         fn = func(_scale_add, a, b)
@@ -53,8 +53,8 @@ def test_func_call_emits_region():
 
 
 def test_func_define_returns_traceobject():
-    x = InterpObject(np.array(1.0), elt.Tensor[elt.f32, ()])
-    y = InterpObject(np.array(3.0), elt.Tensor[elt.f32, ()])
+    x = InterpObject(np.array(1.0), elt.Tensor[elt.f32, ()])  # type: ignore
+    y = InterpObject(np.array(3.0), elt.Tensor[elt.f32, ()])  # type: ignore
 
     def wrapper(a, b):
         return func(_scale_add, a, b)
@@ -66,8 +66,8 @@ def test_func_define_returns_traceobject():
 
 
 def test_func_call_handles_complex_pytree_output():
-    x = InterpObject(np.array(2.0), elt.Tensor[elt.f32, ()])
-    y = InterpObject(np.array(5.0), elt.Tensor[elt.f32, ()])
+    x = InterpObject(np.array(2.0), elt.Tensor[elt.f32, ()])  # type: ignore
+    y = InterpObject(np.array(5.0), elt.Tensor[elt.f32, ()])  # type: ignore
 
     def wrapper(a, b):
         nested_fn = func(_complex_body, a, b)
@@ -110,9 +110,9 @@ def test_func_call_handles_complex_pytree_output():
             (%arg0: Tensor[f32, ()], %arg1: Tensor[f32, ()]) {
               %0 = func.func() {in_morph=(PyTreeDef(((*, *), {})), (0, 1), []), out_morph=(PyTreeDef({'nested': (*, {'orig': *}), 'sum': *}), (0, 1, 2), []), output_types=[Tensor[f32, ()], Tensor[f32, ()], Tensor[f32, ()]], sym_name='_complex_body'} : Custom[function] {
                 (%arg0: Tensor[f32, ()], %arg1: Tensor[f32, ()]) {
-                  %0 = tensor.run_jax(%arg0) {arg_keep_map=None, ir_type='stablehlo', stablehlo_code='<ID>', text_ref='<ID>'} : Tensor[f32, ()]
-                  %1 = tensor.run_jax(%0, %arg1) {arg_keep_map=None, ir_type='stablehlo', stablehlo_code='<ID>', text_ref='<ID>'} : Tensor[f32, ()]
-                  %2 = tensor.run_jax(%1, %arg0) {arg_keep_map=None, ir_type='stablehlo', stablehlo_code='<ID>', text_ref='<ID>'} : Tensor[f32, ()]
+                  %0 = tensor.run_jax(%arg0) {arg_keep_map=None, backend='auto', ir_type='stablehlo', stablehlo_code='<ID>', text_ref='<ID>'} : Tensor[f32, ()]
+                  %1 = tensor.run_jax(%0, %arg1) {arg_keep_map=None, backend='auto', ir_type='stablehlo', stablehlo_code='<ID>', text_ref='<ID>'} : Tensor[f32, ()]
+                  %2 = tensor.run_jax(%1, %arg0) {arg_keep_map=None, backend='auto', ir_type='stablehlo', stablehlo_code='<ID>', text_ref='<ID>'} : Tensor[f32, ()]
                   return %2, %arg1, %1
                 }
               }

--- a/tests/dialects/test_tensor.py
+++ b/tests/dialects/test_tensor.py
@@ -40,6 +40,35 @@ def test_tensor_run_jax_op_emitted():
     assert op.opcode == "tensor.run_jax"
 
 
+def test_tensor_run_jax_on_dynamic_shape():
+    from mplang.dialects.tensor import mark_symbolic_shapes
+
+    tracer = el.get_current_context()
+    value = el.Value("xx", elt.TensorType(elt.f32, (-1,)))
+    obj = el.TraceObject(value, tracer)  # type: ignore
+
+    def wrapper(x):
+        return run_jax(_add_fn, x)
+
+    traced = el.trace(wrapper, obj)
+    op = traced.graph.operations[0]
+    assert "tensor<?xf32>" in op.attrs["stablehlo_code"]
+
+    @mark_symbolic_shapes(in_shapes=[("x", "y"), ("x", "y")])
+    def _add_dim2(x, y):
+        return x + y
+
+    def wrapper1(x, y):
+        return run_jax(_add_dim2, x, y)
+
+    tensor_type = elt.TensorType(elt.f32, (-1, -1))
+    x = el.TraceObject(el.Value("x", tensor_type), tracer)  # type: ignore
+    y = el.TraceObject(el.Value("y", tensor_type), tracer)  # type: ignore
+    traced1 = el.trace(wrapper1, x, y)
+    op1 = traced1.graph.operations[0]
+    assert "tensor<?x?xf32>" in op1.attrs["stablehlo_code"]
+
+
 def test_tensor_transpose_op():
     """Test transpose operation with ranked tensors."""
     x = InterpObject(

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,43 @@ wheels = [
 ]
 
 [[package]]
+name = "iree-compiler"
+version = "20241104.1068"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/d8/e5ff81b96ca02008fb639370480a149102a7ad854d9946fd4be72a2fcd57/iree_compiler-20241104.1068-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:7d674456d46fc1ea861a00642fa5ad9045d6f9c7d5482dd7f8bab3ca462543bb", size = 57583974, upload-time = "2024-11-05T23:33:38.226Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/24/e7/c0d50c74f1613e17ddeef509f885194ba0a75ee6bb83cac1c886a9be3adf/iree_compiler-20241104.1068-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:740d5f34aad78aa509038c27df0b9d4c43781fc6db48152257934046da15ae3d", size = 71919533, upload-time = "2024-11-05T23:33:43.431Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/84/b50c55d6727d6aa04cc413aac0f0e38920c6d14ff9a9cb2fbeecca439064/iree_compiler-20241104.1068-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aeac74cc2e3eb34a453427df2c5ddbe85e9d8ee942dc97eae42ead6fc8f24fa8", size = 70733516, upload-time = "2024-11-05T23:33:48.71Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/f8/ee5591301ee2e3119aaa0838d9d8fa1d6007fcc558417bdbe0c3f15b3ef9/iree_compiler-20241104.1068-cp311-cp311-win_amd64.whl", hash = "sha256:62a64945b5b269d9a3f20c80dc1dc335ca1961365e6ec4ee31c27b0e5197cfec", size = 49797842, upload-time = "2024-11-05T23:33:54.126Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/86/1bd674964d67effad4d9187afa75814ce8505bb6998b4e1bdaa73a46e355/iree_compiler-20241104.1068-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:2077182344235f75b8c7707586f24a3b68d556ccc5771e0926f14819d6115e03", size = 57591226, upload-time = "2024-11-05T23:33:58.704Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/ee/4e6bbeace037bb449dd539912afcba3ea5a88f2fe9494d74161a200f1532/iree_compiler-20241104.1068-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87f49105a10825a68055226e7e3fbf313590d766ad208ab70d35f6ab79044775", size = 71931372, upload-time = "2024-11-05T23:34:04.302Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/6e/87756b7be8b2235c398283589e7591f917b8df4c5cef1d660ea43d15ec85/iree_compiler-20241104.1068-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eb1c01a208399c844ac961ef52aeb6be780db4f87fac59ceeb59b8d8c68719", size = 70763482, upload-time = "2024-11-05T23:34:10.82Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/c5/ccb4a5355c3231d2d9d55740b4024cf6b1f3a1155a1a5268db0425c59ca3/iree_compiler-20241104.1068-cp312-cp312-win_amd64.whl", hash = "sha256:2e7e88b4e63caf529c0ad4f1e55cfd7624e0ac0bf4034cd7e0f935f23251073c", size = 49804740, upload-time = "2024-11-05T23:34:15.776Z" },
+]
+
+[[package]]
+name = "iree-runtime"
+version = "20241104.1068"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/7d/4cb7af5459ddded9854ded4a342a4d2993e3b84789eef488ae5a8ae25efb/iree_runtime-20241104.1068-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:e2f2c188965114a4dda5d93d457c414ed63c915866a9699e9a9676d1e87e642c", size = 3812770, upload-time = "2024-11-05T23:43:37.759Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fd/11/2454a66f7ffc2b86ac188c9bcc0e4c1cda3737eb425639fc4414a56ec200/iree_runtime-20241104.1068-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:83e880b45e7f82e73be17f04dd4a6793a0e3f1c3e058c6642932ca091c7ebded", size = 7941895, upload-time = "2024-11-05T23:43:40.098Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/e2/0ce63cc3b6b7e71dc71441830eb34a5fe415cce8d21ca915a18548ef6c6c/iree_runtime-20241104.1068-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:50b35be116589b154ae807747727c9ecc8851958d7137a440d58592b4b1adbb8", size = 8039523, upload-time = "2024-11-05T23:43:42.543Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f8/af/a1d19d316b8fd22620e44047a62c497ddfcae7b5f5f5081c4db439083e43/iree_runtime-20241104.1068-cp311-cp311-win_amd64.whl", hash = "sha256:cfa02dfae6644bb6ce3a9c3995cb6287ebb13de5881304aa21cd21ab44fbc7b5", size = 5282077, upload-time = "2024-11-05T23:43:44.809Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/21/e4/aebf18d31aa0a9c820371a97bdd3f9834f780ab5aeeebcad751139555acf/iree_runtime-20241104.1068-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:4a0c52dfe2443bdc47c2990d55423579d9cd9e0da7d0df50c685d6b8b474c3ee", size = 3812435, upload-time = "2024-11-05T23:43:46.595Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/ec/4eab1dd626d2e7e48c424c31678196a622d0374b0f718091e809464ee75f/iree_runtime-20241104.1068-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:488efb65428d0525bfec628380c49662cd27a7a3f2fb510e9b0f50fa0058fa47", size = 7940985, upload-time = "2024-11-05T23:43:49.128Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/1e/f55daece2adafb20c3ae23ba6a78cf582a7aa1b1ff468d3c4e4d92fcd899/iree_runtime-20241104.1068-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:38a052b97c81a71c6c5c7a82e8395d0537bd88cbf0e2847575512464a7f04f8c", size = 8041669, upload-time = "2024-11-05T23:43:51.498Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/7c/17976da37bd02e508e6f8062a6eb5396f2d69f80346ced04ef213b7d9a56/iree_runtime-20241104.1068-cp312-cp312-win_amd64.whl", hash = "sha256:8f1b288773a63ef0289ab492396cc12399e1fcd6e5c6841547a4f6f658143c50", size = 5283903, upload-time = "2024-11-05T23:43:53.861Z" },
+]
+
+[[package]]
 name = "jax"
 version = "0.8.0"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -865,6 +902,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "flax" },
     { name = "httpx" },
+    { name = "iree-compiler" },
+    { name = "iree-runtime" },
     { name = "jax" },
     { name = "lightphe" },
     { name = "numpy" },
@@ -905,6 +944,8 @@ requires-dist = [
     { name = "fastapi" },
     { name = "flax", specifier = ">=0.12.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "iree-compiler" },
+    { name = "iree-runtime" },
     { name = "jax", extras = ["cpu"], specifier = "==0.8.0" },
     { name = "lightphe", specifier = ">=0.0.15,<0.1.0" },
     { name = "numpy", specifier = ">=2.0.0,!=2.4.0" },


### PR DESCRIPTION
- run_jax支持jax.uses_shape_polymorphism动态shape(使用-1表示), 执行时需要iree
- run_jax_impl后端保留了iree和xla两种引擎，当前默认使用xla,因为iree有些操作不支持，比如jnp.packbits/jnp.unpackbits/`jnp.fliplr` / `jnp.flip`/jnp.reverse这些函数会执行reverse操作，iree不支持.
- 新增mark_symbolic_shapes函数用于标记symbolic_shape
- 由于spu编译的是mhlo而不是stablehlo，导致无法支持dynamic shape,但spu自身可以将-1转化为1,执行时自动根据数据的shape计算。