### PR TITLE
fix: preserve dynamic output shapes from SPU's JAX compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ pylintrc
 
 # Temporary files
 tmp/
+.tmp/
 
 # LLM
 CLAUDE.md

--- a/mplang/dialects/_jax_utils.py
+++ b/mplang/dialects/_jax_utils.py
@@ -20,7 +20,6 @@ from typing import Any
 import jax
 from jax.tree_util import PyTreeDef
 
-import mplang as mp
 import mplang.edsl as el
 import mplang.edsl.typing as elt
 from mplang.dialects import dtypes
@@ -94,7 +93,7 @@ def _make_placeholders(
 
     placeholders: list[jax.ShapeDtypeStruct] = []
     for obj_idx, obj in enumerate(variables):
-        #
+        # Extract the plain tensor type from SS (Secret Sharing) type if needed
         obj_type = obj.type.pt_type if isinstance(obj.type, elt.SSType) else obj.type
 
         if not isinstance(obj_type, (elt.TensorType, elt.ScalarType)):
@@ -112,7 +111,7 @@ def _make_placeholders(
             for idx, dim in enumerate(obj_type.shape):
                 if dim is None:
                     raise TypeError(
-                        f"tensor.run_jax argument dimension {idx} is None; "
+                        f"Argument dimension {idx} is None; "
                         "please provide a static dimension."
                     )
                 elif dim < -1:
@@ -131,7 +130,7 @@ def _make_placeholders(
 
 def compile_jax(
     normalized_fn: Callable[..., Any],
-    variables: list[mp.Object],
+    variables: list[el.Object],
     symbolic_shapes: Sequence[Sequence[str | None]] | None = None,
 ) -> JaxCompilation:
     """Compile JAX function to StableHLO MLIR.
@@ -139,12 +138,16 @@ def compile_jax(
     Pipeline: jit → export → StableHLO MLIR
 
     Args:
-        fn: Original JAX function
         normalized_fn: Function accepting list of variables (for JAX lower API)
-        placeholders: JAX ShapeDtypeStruct list for lowering
+        variables: List of MPLang objects representing function inputs
+        symbolic_shapes: Optional sequence of symbolic shape names for dynamic dimensions.
+            Each inner sequence corresponds to an input variable's dimensions, with None
+            for static dimensions and string names for symbolic dimensions.
 
     Returns:
-        Tuple of (compilation record, compilation_id)
+        JaxCompilation: Compilation record containing StableHLO MLIR, output types,
+        tree structure, and metadata for execution including arg_keep_map for JAX's
+        unused parameter elimination and dynamic shape flag.
     """
 
     placeholders = _make_placeholders(variables, symbolic_shapes)

--- a/mplang/dialects/_jax_utils.py
+++ b/mplang/dialects/_jax_utils.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+from jax.tree_util import PyTreeDef
+
+import mplang as mp
+import mplang.edsl as el
+import mplang.edsl.typing as elt
+from mplang.dialects import dtypes
+
+
+@dataclass
+class JaxCompilation:
+    """Compilation record for tensor.run_jax functions.
+
+    Stores both the compilation artifacts (StableHLO MLIR, types, tree structure)
+    and metadata needed for execution (arg_keep_map for JAX's unused param elimination).
+    """
+
+    stablehlo: str
+    out_tree: PyTreeDef  # type: ignore
+    output_types: list[elt.TensorType]
+    arg_keep_map: list[int] | None = None
+    has_dynamic_shape: bool = False
+
+
+def _scalar_to_dtype(scalar: elt.ScalarType) -> Any:
+    """Convert MPLang scalar type to JAX dtype.
+
+    JAX ShapeDtypeStruct automatically handles conversion to numpy dtype internally.
+    """
+    return dtypes.to_jax(scalar)
+
+
+def _dtype_to_scalar(dtype: Any) -> elt.ScalarType:
+    return dtypes.from_dtype(dtype)
+
+
+def _out_info_to_edsl(out_info: Any) -> elt.TensorType:
+    scalar = _dtype_to_scalar(out_info.dtype)
+    shape = [dim if isinstance(dim, int) else -1 for dim in out_info.shape]
+    return elt.TensorType(scalar, tuple(shape))
+
+
+def _get_symbolic_name(
+    symbolic_shapes: Sequence[Sequence[str | None]] | None, obj_idx: int, dim_idx: int
+) -> str:
+    if (
+        symbolic_shapes is not None
+        and obj_idx < len(symbolic_shapes)
+        and dim_idx < len(symbolic_shapes[obj_idx])
+    ):
+        name = symbolic_shapes[obj_idx][dim_idx]
+        if not isinstance(name, str):
+            raise ValueError(f"Symbolic shape name must be a string, got {type(name)}")
+        return name
+
+    # We use "n_rows" instead of generic pattern like f"arg_{obj_idx}_dim_{dim_idx}"
+    # because our common use case is representing unknown row count in tabular data
+    return "n_rows"
+
+
+def _make_placeholders(
+    variables: list[el.Object], symbolic_shapes: Sequence[Sequence[str | None]] | None
+) -> list[jax.ShapeDtypeStruct]:
+    # Build symbolic shapes and placeholders
+    symbol_scope = jax.export.SymbolicScope()
+    # Maps symbol name to SymbolicDimension
+    symbol_map: dict[str, Any] = {}
+
+    def _make_symbol(name: str) -> Any:
+        if name in symbol_map:
+            return symbol_map[name]
+        symbolics = jax.export.symbolic_shape(name, scope=symbol_scope)
+        symbol_map[name] = symbolics[0]
+        return symbolics[0]
+
+    placeholders: list[jax.ShapeDtypeStruct] = []
+    for obj_idx, obj in enumerate(variables):
+        #
+        obj_type = obj.type.pt_type if isinstance(obj.type, elt.SSType) else obj.type
+
+        if not isinstance(obj_type, (elt.TensorType, elt.ScalarType)):
+            raise TypeError(f"run_jax only supports Tensors/Scalars, got {obj.type}")
+        if isinstance(obj_type, elt.ScalarType):
+            dtype = _scalar_to_dtype(obj_type)
+            placeholders.append(jax.ShapeDtypeStruct((), dtype))
+        else:
+            # element_type must be ScalarType for conversion to numpy dtype
+            if not isinstance(obj_type.element_type, elt.ScalarType):
+                raise TypeError(
+                    f"Expected ScalarType element, got {type(obj_type.element_type)}"
+                )
+            obj_shape = []
+            for idx, dim in enumerate(obj_type.shape):
+                if dim is None:
+                    raise TypeError(
+                        f"tensor.run_jax argument dimension {idx} is None; "
+                        "please provide a static dimension."
+                    )
+                elif dim < -1:
+                    raise ValueError(f"Invalid tensor dimension {dim}")
+                if dim == -1:
+                    name = _get_symbolic_name(symbolic_shapes, obj_idx, idx)
+                    symbol = _make_symbol(name)
+                    obj_shape.append(symbol)
+                else:
+                    obj_shape.append(dim)
+            dtype = _scalar_to_dtype(obj_type.element_type)
+            placeholders.append(jax.ShapeDtypeStruct(obj_shape, dtype))
+
+    return placeholders
+
+
+def compile_jax(
+    normalized_fn: Callable[..., Any],
+    variables: list[mp.Object],
+    symbolic_shapes: Sequence[Sequence[str | None]] | None = None,
+) -> JaxCompilation:
+    """Compile JAX function to StableHLO MLIR.
+
+    Pipeline: jit → export → StableHLO MLIR
+
+    Args:
+        fn: Original JAX function
+        normalized_fn: Function accepting list of variables (for JAX lower API)
+        placeholders: JAX ShapeDtypeStruct list for lowering
+
+    Returns:
+        Tuple of (compilation record, compilation_id)
+    """
+
+    placeholders = _make_placeholders(variables, symbolic_shapes)
+
+    # Calculate has_dynamic_shape from placeholders
+    # Check if any placeholder has symbolic dimensions (i.e., non-concrete shape)
+    has_dynamic_shape = any(
+        not all(isinstance(dim, int) for dim in placeholder.shape)
+        for placeholder in placeholders
+    )
+
+    # Wrap normalized_fn to collect JAX's individual args into a list
+    # This is needed because:
+    # - normalized_fn expects: normalized([arg1, arg2, ...])
+    # - But JAX export calls: wrapper_fn(arg1, arg2, ...)
+    def wrapped_fn(*args: Any) -> Any:
+        return normalized_fn(list(args))
+
+    # Tip: Use `jax.config.update("jax_traceback_in_locations_limit", 0)` to reduce location information
+    # in MLIR output. This disables JAX traceback locations, removing verbose source location
+    # annotations (e.g., #loc = #loc1) from the generated MLIR, which makes the output more
+    # readable and reduces serialization overhead.
+    jitted = jax.jit(wrapped_fn)
+    exported = jax.export.export(jitted)(*placeholders)
+    stablehlo_text = str(exported.mlir_module())
+
+    # Handle JAX's unused parameter elimination
+    arg_keep_map: list[int] | None = None
+    try:
+        kept_var_idx = exported.module_kept_var_idx
+        if len(kept_var_idx) < len(placeholders):
+            arg_keep_map = list(kept_var_idx)
+    except (AttributeError, TypeError) as e:
+        raise RuntimeError(
+            f"Cannot access JAX's module_kept_var_idx for unused parameter handling. "
+            f"JAX may have optimized away unused parameters. Error: {e}"
+        ) from e
+
+    # Convert output info to EDSL types
+    output_types: list[elt.TensorType]
+    if isinstance(exported.out_avals, tuple):
+        output_types = [_out_info_to_edsl(aval) for aval in exported.out_avals]
+    else:
+        output_types = [_out_info_to_edsl(exported.out_avals)]
+
+    compilation = JaxCompilation(
+        stablehlo=stablehlo_text,
+        out_tree=exported.out_tree,
+        output_types=output_types,
+        arg_keep_map=arg_keep_map,
+        has_dynamic_shape=has_dynamic_shape,
+    )
+    return compilation

--- a/mplang/dialects/spu.py
+++ b/mplang/dialects/spu.py
@@ -75,7 +75,7 @@ z = spu.reconstruct(tuple(z_shares))
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, cast
 
@@ -184,8 +184,7 @@ def _exec_ae(
     executable: bytes,
     input_vis: list[Visibility],
     output_vis: list[Visibility],
-    output_shapes: list[tuple[int, ...]],
-    output_dtypes: list[elt.ScalarType],
+    output_types: list[elt.TensorType],
     input_names: list[str],
     output_names: list[str],
     config: SPUConfig,
@@ -197,9 +196,7 @@ def _exec_ae(
             raise TypeError(f"spu.exec expects SSType or TensorType inputs, got {arg}")
 
     # Outputs are SS[Tensor]
-    outputs: list[elt.SSType[Any]] = []
-    for shape, dtype in zip(output_shapes, output_dtypes, strict=True):
-        outputs.append(elt.SS(elt.Tensor(dtype, shape)))
+    outputs: list[elt.SSType[Any]] = [elt.SS(dt) for dt in output_types]
 
     if len(outputs) == 1:
         return outputs[0]
@@ -244,7 +241,13 @@ def reconstruct(config: SPUConfig, shares: tuple[el.Object, ...]) -> el.Object:
     return reconstruct_p.bind(*shares, config=config)
 
 
-def run_jax(config: SPUConfig, fn: Callable, *args: Any, **kwargs: Any) -> Any:
+def run_jax(
+    config: SPUConfig,
+    fn: Callable,
+    *args: Any,
+    symbolic_shapes: Sequence[Sequence[str | None]] | None = None,
+    **kwargs: Any,
+) -> Any:
     """Execute a function on SPU locally.
 
     This function should be called inside a `simp.pcall` region.
@@ -267,6 +270,7 @@ def run_jax(config: SPUConfig, fn: Callable, *args: Any, **kwargs: Any) -> Any:
     # 2. Validate inputs and prepare for compilation
     jax_args_flat = []
     input_vis: list[Visibility] = []  # String-based visibility for IR
+    has_dynamic_shape = False
 
     for arg in in_vars:
         if isinstance(arg.type, elt.SSType):
@@ -284,6 +288,8 @@ def run_jax(config: SPUConfig, fn: Callable, *args: Any, **kwargs: Any) -> Any:
         # Map to JAX
         jax_dtype = dtypes.to_jax(cast(elt.ScalarType, pt_type.element_type))
         shape = tuple(d if d != -1 else 1 for d in pt_type.shape)
+        if not has_dynamic_shape:
+            has_dynamic_shape = any(d == -1 for d in pt_type.shape)
 
         jax_args_flat.append(ShapeDtypeStruct(shape, jax_dtype))
         input_vis.append(vis)
@@ -312,19 +318,27 @@ def run_jax(config: SPUConfig, fn: Callable, *args: Any, **kwargs: Any) -> Any:
     )
 
     # 4. Execute SPU Kernel
-    flat_outputs_info, out_tree = tree_flatten(output_info)
-    output_shapes = [out.shape for out in flat_outputs_info]
+    if has_dynamic_shape:
+        from ._jax_utils import compile_jax
 
-    output_dtypes = [dtypes.from_dtype(out.dtype) for out in flat_outputs_info]
-    output_vis_list: list[Visibility] = ["secret"] * len(flat_outputs_info)
+        # Fix output shape by ensuring symbolic dimensions are represented as -1
+        compilation = compile_jax(normalized_fn, in_vars, symbolic_shapes)
+        output_types = compilation.output_types
+        out_tree = compilation.out_tree
+    else:
+        flat_outputs_info, out_tree = tree_flatten(output_info)
+        output_types = [
+            elt.TensorType(dtypes.from_dtype(out.dtype), out.shape)
+            for out in flat_outputs_info
+        ]
+    output_vis_list: list[Visibility] = ["secret"] * len(output_types)
 
     res_shares = exec_p.bind(
         *in_vars,
         executable=executable.code,
         input_vis=input_vis,
         output_vis=output_vis_list,
-        output_shapes=output_shapes,
-        output_dtypes=output_dtypes,
+        output_types=output_types,
         input_names=executable.input_names,
         output_names=executable.output_names,
         config=config,

--- a/mplang/dialects/spu.py
+++ b/mplang/dialects/spu.py
@@ -256,7 +256,12 @@ def run_jax(
     Args:
         config: SPU configuration.
         fn: The function to execute.
-        *args: Positional arguments (SSType or TensorType).
+        *args: Positional arguments (SSType or TensorType). For dynamic shapes,
+            tensors can have dimensions as -1 to indicate unknown size.
+        symbolic_shapes: Optional sequence of symbolic shape names for dynamic dimensions.
+            Each inner sequence corresponds to an input argument's dimensions:
+            - Use None for static dimensions
+            - Use string names (e.g., "n_rows", "batch_size") for dynamic dimensions
         **kwargs: Keyword arguments.
     """
 

--- a/mplang/dialects/tensor.py
+++ b/mplang/dialects/tensor.py
@@ -49,14 +49,12 @@ import base64
 import functools
 import math
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
 from itertools import count
 from typing import Any, cast
 from weakref import WeakKeyDictionary
 
-import jax
 import numpy as np
-from jax.tree_util import PyTreeDef, tree_flatten
+from jax.tree_util import tree_flatten
 
 import mplang.edsl as el
 import mplang.edsl.typing as elt
@@ -64,27 +62,13 @@ from mplang.dialects import dtypes
 from mplang.utils import normalize_fn
 from mplang.utils.func_utils import MorphStruct
 
+from ._jax_utils import JaxCompilation, compile_jax
+
 run_jax_p = el.Primitive[Any]("tensor.run_jax")
 constant_p = el.Primitive[el.Object]("tensor.constant")
 
 
-@dataclass
-class RunJaxCompilation:
-    """Compilation record for tensor.run_jax functions.
-
-    Stores both the compilation artifacts (StableHLO MLIR, types, tree structure)
-    and metadata needed for execution (arg_keep_map for JAX's unused param elimination).
-    """
-
-    fn: Callable[..., Any]
-    stablehlo: str
-    out_tree: PyTreeDef  # type: ignore
-    output_types: list[elt.BaseType]
-    arg_keep_map: list[int] | None = None
-    has_dynamic_shape: bool = False
-
-
-_RUN_JAX_REGISTRY: dict[str, RunJaxCompilation] = {}
+_RUN_JAX_REGISTRY: dict[str, JaxCompilation] = {}
 _RUN_JAX_ID_GENERATOR = count()
 
 
@@ -95,27 +79,13 @@ def _current_tracer() -> el.Tracer:
     return ctx
 
 
-def _scalar_to_numpy_dtype(scalar: elt.ScalarType) -> np.dtype[np.generic]:
-    return np.dtype(dtypes.to_jax(scalar))  # type: ignore[no-any-return]
-
-
-def _numpy_dtype_to_scalar(dtype: Any) -> elt.ScalarType:
-    return dtypes.from_dtype(dtype)
-
-
-def _out_info_to_edsl(out_info: Any) -> elt.TensorType:
-    scalar = _numpy_dtype_to_scalar(out_info.dtype)
-    shape = [dim if isinstance(dim, int) else -1 for dim in out_info.shape]
-    return elt.TensorType(scalar, tuple(shape))
-
-
-def _register_compilation(compilation: RunJaxCompilation) -> str:
+def _register_compilation(compilation: JaxCompilation) -> str:
     compilation_id = f"tensor.run_jax::{next(_RUN_JAX_ID_GENERATOR)}"
     _RUN_JAX_REGISTRY[compilation_id] = compilation
     return compilation_id
 
 
-def get_run_jax_compilation(compilation_id: str) -> RunJaxCompilation:
+def get_jax_compilation(compilation_id: str) -> JaxCompilation:
     """Get compilation record by ID.
 
     Returns:
@@ -129,211 +99,13 @@ def get_run_jax_compilation(compilation_id: str) -> RunJaxCompilation:
         ) from exc
 
 
-def mark_symbolic_shapes(
-    fn: Callable | None = None, *, in_shapes: Sequence[Sequence[str | None]]
-) -> Callable:
-    """Mark symbolic shapes for function parameters.
-
-    This function can be used as a decorator or applied directly to a function.
-    It marks the input parameters with symbolic shape specifications where
-    dynamic dimensions are represented by strings and None indicates static shapes.
-
-    Args:
-        fn: Function to mark (when used directly, not as decorator)
-        in_shapes: List of shape specifications for each parameter.
-                  Each element can be:
-                  - None: Use static shape (don't mark)
-                  - List/tuple of dimensions: Each dimension can be:
-                    - str: Symbolic dimension name (e.g., "batch", "seq_len")
-                    - None: Static (will be inferred from actual input)
-
-    Returns:
-        The function with symbolic shapes marked
-
-    Examples:
-        # As decorator
-        @mark_symbolic_shapes(in_shapes=[("batch", "seq_len"), ("seq_len", "hidden")])
-        def matmul(x, y):
-            return jnp.matmul(x, y)
-
-        # Applied directly
-        def add(x, y):
-            return x + y
-        add = mark_symbolic_shapes(add, in_shapes=[("batch",), ("batch",)])
-    """
-
-    def decorator(func: Callable) -> Callable:
-        # Store symbolic shapes information on the function
-        cast(Any, func)._symbolic_shapes = in_shapes
-        return func
-
-    if fn is not None:
-        # Direct application mode
-        return decorator(fn)
-    else:
-        # Decorator mode
-        return decorator
-
-
-def _get_symbolic_shapes(fn: Callable) -> Sequence[Sequence[str | None]] | None:
-    """Get symbolic shapes information from a marked function.
-
-    Args:
-        fn: Function that was marked with mark_symbolic_shapes
-
-    Returns:
-        Dictionary with symbolic shapes information or None if not marked
-    """
-    if hasattr(fn, "_symbolic_shapes"):
-        return cast(Sequence[Sequence[str | None]], fn._symbolic_shapes)  # type: ignore[attr-defined]
-
-    # Also check the original function if fn is a wrapper
-    if hasattr(fn, "__wrapped__"):
-        return _get_symbolic_shapes(fn.__wrapped__)
-
-    return None
-
-
-def _get_symbolic_name(
-    symbolic_shapes: Sequence[Sequence[str | None]] | None, obj_idx: int, dim_idx: int
-) -> str:
-    if (
-        symbolic_shapes is not None
-        and obj_idx < len(symbolic_shapes)
-        and dim_idx < len(symbolic_shapes[obj_idx])
-    ):
-        name = symbolic_shapes[obj_idx][dim_idx]
-        if not isinstance(name, str):
-            raise ValueError(f"Symbolic shape name must be a string, got {type(name)}")
-        return name
-
-    # We use "n_rows" instead of generic pattern like f"arg_{obj_idx}_dim_{dim_idx}"
-    # because our common use case is representing unknown row count in tabular data
-    return "n_rows"
-
-
-def _make_placeholders(
-    variables: list[el.Object], symbolic_shapes: Sequence[Sequence[str | None]] | None
-) -> list[jax.ShapeDtypeStruct]:
-    # Build symbolic shapes and placeholders
-    symbol_scope = jax.export.SymbolicScope()
-    # Maps symbol name to SymbolicDimension
-    symbol_map: dict[str, Any] = {}
-
-    def _make_symbol(name: str) -> Any:
-        if name in symbol_map:
-            return symbol_map[name]
-        symbolics = jax.export.symbolic_shape(name, scope=symbol_scope)
-        symbol_map[name] = symbolics[0]
-        return symbolics[0]
-
-    placeholders: list[jax.ShapeDtypeStruct] = []
-    for obj_idx, obj in enumerate(variables):
-        if not isinstance(obj.type, (elt.TensorType, elt.ScalarType)):
-            raise TypeError(f"run_jax only supports Tensors/Scalars, got {obj.type}")
-        if isinstance(obj.type, elt.ScalarType):
-            dtype = _scalar_to_numpy_dtype(obj.type)
-            placeholders.append(jax.ShapeDtypeStruct((), dtype))
-        else:
-            # element_type must be ScalarType for conversion to numpy dtype
-            if not isinstance(obj.type.element_type, elt.ScalarType):
-                raise TypeError(
-                    f"Expected ScalarType element, got {type(obj.type.element_type)}"
-                )
-            obj_shape = []
-            for idx, dim in enumerate(obj.type.shape):
-                if dim is None:
-                    raise TypeError(
-                        f"tensor.run_jax argument dimension {idx} is None; "
-                        "please provide a static dimension."
-                    )
-                elif dim < -1 or dim == 0:
-                    raise ValueError(f"Invalid tensor dimension {dim}")
-                if dim == -1:
-                    name = _get_symbolic_name(symbolic_shapes, obj_idx, idx)
-                    symbol = _make_symbol(name)
-                    obj_shape.append(symbol)
-                else:
-                    obj_shape.append(dim)
-            dtype = _scalar_to_numpy_dtype(obj.type.element_type)
-            placeholders.append(jax.ShapeDtypeStruct(obj_shape, dtype))
-
-    return placeholders
-
-
-def _compile_run_jax(
-    fn: Callable[..., Any],
-    normalized_fn: Callable[..., Any],
-    placeholders: list[jax.ShapeDtypeStruct],
-) -> tuple[RunJaxCompilation, str]:
-    """Compile JAX function to StableHLO MLIR.
-
-    Pipeline: jit → export → StableHLO MLIR
-
-    Args:
-        fn: Original JAX function
-        normalized_fn: Function accepting list of variables (for JAX lower API)
-        placeholders: JAX ShapeDtypeStruct list for lowering
-
-    Returns:
-        Tuple of (compilation record, compilation_id)
-    """
-
-    # Calculate has_dynamic_shape from placeholders
-    # Check if any placeholder has symbolic dimensions (i.e., non-concrete shape)
-    has_dynamic_shape = any(
-        not all(isinstance(dim, int) for dim in placeholder.shape)
-        for placeholder in placeholders
-    )
-
-    # Wrap normalized_fn to collect JAX's individual args into a list
-    # This is needed because:
-    # - normalized_fn expects: normalized([arg1, arg2, ...])
-    # - But JAX export calls: wrapper_fn(arg1, arg2, ...)
-    def wrapped_fn(*args: Any) -> Any:
-        return normalized_fn(list(args))
-
-    # Tip: Use `jax.config.update("jax_traceback_in_locations_limit", 0)` to reduce location information
-    # in MLIR output. This disables JAX traceback locations, removing verbose source location
-    # annotations (e.g., #loc = #loc1) from the generated MLIR, which makes the output more
-    # readable and reduces serialization overhead.
-    jitted = jax.jit(wrapped_fn)
-    exported = jax.export.export(jitted)(*placeholders)
-    stablehlo_text = str(exported.mlir_module())
-
-    # Handle JAX's unused parameter elimination
-    arg_keep_map: list[int] | None = None
-    try:
-        kept_var_idx = exported.module_kept_var_idx
-        if len(kept_var_idx) < len(placeholders):
-            arg_keep_map = list(kept_var_idx)
-    except (AttributeError, TypeError) as e:
-        raise RuntimeError(
-            f"Cannot access JAX's module_kept_var_idx for unused parameter handling. "
-            f"JAX may have optimized away unused parameters. Error: {e}"
-        ) from e
-
-    # Convert output info to EDSL types
-    output_types: list[elt.BaseType]
-    if isinstance(exported.out_avals, tuple):
-        output_types = [_out_info_to_edsl(aval) for aval in exported.out_avals]
-    else:
-        output_types = [_out_info_to_edsl(exported.out_avals)]
-
-    compilation = RunJaxCompilation(
-        fn=fn,
-        stablehlo=stablehlo_text,
-        out_tree=exported.out_tree,
-        output_types=output_types,
-        arg_keep_map=arg_keep_map,
-        has_dynamic_shape=has_dynamic_shape,
-    )
-    compilation_id = _register_compilation(compilation)
-    return compilation, compilation_id
-
-
 @run_jax_p.def_trace
-def _run_jax_trace(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+def _run_jax_trace(
+    fn: Callable[..., Any],
+    *args: Any,
+    symbolic_shapes: Sequence[Sequence[str | None]] | None = None,
+    **kwargs: Any,
+) -> Any:
     """Trace tensor.run_jax primitive.
 
     Compiles JAX function to StableHLO and emits graph operation.
@@ -357,22 +129,20 @@ def _run_jax_trace(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
 
     normalized_fn, variables = normalize_fn(fn, args, kwargs, _is_trace_object)
 
-    symbolic_shapes = _get_symbolic_shapes(fn)
-    placeholders = _make_placeholders(variables, symbolic_shapes)
-
     # Compile to StableHLO
-    compilation, text_ref = _compile_run_jax(fn, normalized_fn, placeholders)
+    compilation = compile_jax(normalized_fn, variables, symbolic_shapes)
+    compilation_id = _register_compilation(compilation)
 
     # Emit graph operation
     backend = "iree" if compilation.has_dynamic_shape else "auto"
-    input_values = [var._graph_value for var in variables]
+    input_values = [cast(el.TraceObject, var)._graph_value for var in variables]
     result_values = tracer.graph.add_op(
         opcode="tensor.run_jax",
         inputs=input_values,
         output_types=compilation.output_types,
         attrs={
             "ir_type": "stablehlo",
-            "text_ref": text_ref,
+            "text_ref": compilation_id,
             "stablehlo_code": compilation.stablehlo,
             "arg_keep_map": compilation.arg_keep_map,
             "backend": backend,
@@ -391,6 +161,7 @@ def _run_jax_trace(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
 def run_jax(
     fn: Callable[..., Any],
     *args: Any,
+    symbolic_shapes: Sequence[Sequence[str | None]] | None = None,
     **kwargs: Any,
 ) -> Any:
     """Trace a tensor JAX function as a graph op.
@@ -405,7 +176,7 @@ def run_jax(
     Returns:
         PyTree of TraceObjects with the same structure as fn's output.
     """
-    return run_jax_p.bind(fn, *args, **kwargs)
+    return run_jax_p.bind(fn, *args, symbolic_shapes=symbolic_shapes, **kwargs)
 
 
 def jax_fn(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -457,7 +228,7 @@ def _constant_trace(data: Any) -> el.TraceObject:
 
     # Unified numpy conversion for all data types
     np_array = np.array(data)
-    dtype = _numpy_dtype_to_scalar(np_array.dtype)
+    dtype = dtypes.from_dtype(np_array.dtype)
     shape = tuple(np_array.shape)
     output_type: elt.TensorType = elt.TensorType(dtype, shape)
 
@@ -1265,7 +1036,7 @@ def bitcast(x: el.Object, dtype: elt.ScalarType) -> el.Object:
 
 
 __all__ = [
-    "RunJaxCompilation",
+    "JaxCompilation",
     "bitcast",
     "concat",
     "concat_p",
@@ -1275,9 +1046,8 @@ __all__ = [
     "elementwise_p",
     "gather",
     "gather_p",
-    "get_run_jax_compilation",
+    "get_jax_compilation",
     "jax_fn",
-    "mark_symbolic_shapes",
     "reshape",
     "reshape_p",
     "run_jax",

--- a/tests/backends/test_spu_impl.py
+++ b/tests/backends/test_spu_impl.py
@@ -202,10 +202,8 @@ def test_spu_run_dynamic_shape():
     1. Compile with dynamic shape (-1) - shape unknown at compile time
     2. Execute multiple times with different actual data to demonstrate dynamic behavior
     """
+
     # Phase 1: Setup and compilation
-    world_size = 3
-    sim = simp.make_simulator(world_size=world_size)
-    mp.set_root_context(sim)
 
     # Define computation
     def jax_add(x, y):
@@ -268,17 +266,26 @@ def test_spu_run_dynamic_shape():
         np.arange(5, dtype=np.float32),  # Size 5
     ]
 
-    for input_data in test_cases:
-        # Need to run within simp context since this uses simp operations
-        with sim:
-            # Create MP objects from the input data
-            x_mp = simp.constant((0,), input_data)
-            y_mp = simp.constant((0,), input_data)
+    world_size = 3
+    sim = simp.make_simulator(world_size=world_size)
+    mp.set_root_context(sim)
 
-            # Execute the compiled function with MP objects
-            result = mp.evaluate(traced_fn, x_mp, y_mp)
+    try:
+        for input_data in test_cases:
+            # Need to run within simp context since this uses simp operations
+            with sim:
+                # Create MP objects from the input data
+                x_mp = simp.constant((0,), input_data)
+                y_mp = simp.constant((0,), input_data)
 
-        # Verify the result - need to fetch from DriverVar
-        expected = input_data + input_data
-        result_values = mp.fetch(result)
-        np.testing.assert_allclose(result_values[0], expected)
+                # Execute the compiled function with MP objects
+                result = mp.evaluate(traced_fn, x_mp, y_mp)
+
+            # Verify the result - need to fetch from DriverVar
+            expected = input_data + input_data
+            result_values = mp.fetch(result)
+            np.testing.assert_allclose(result_values[0], expected)
+    finally:
+        # Shutdown the cluster via the interpreter's reference
+        if hasattr(sim, "_simp_cluster"):
+            sim._simp_cluster.shutdown()

--- a/tests/backends/test_spu_impl.py
+++ b/tests/backends/test_spu_impl.py
@@ -20,6 +20,7 @@ import mplang as mp
 import mplang.backends.tensor_impl
 import mplang.edsl as el
 from mplang.dialects import simp, spu
+from mplang.edsl import typing as elt
 
 
 def test_spu_e2e_simulation():
@@ -192,3 +193,92 @@ def test_spu_channels_mode_simulation():
     finally:
         if hasattr(sim, "_simp_cluster"):
             sim._simp_cluster.shutdown()
+
+
+def test_spu_run_dynamic_shape():
+    """Test SPU backend with dynamic shapes (using -1 for unknown dimensions).
+
+    This test follows the exact pattern from test_tensor_run_dynamic_shape:
+    1. Compile with dynamic shape (-1) - shape unknown at compile time
+    2. Execute multiple times with different actual data to demonstrate dynamic behavior
+    """
+    # Phase 1: Setup and compilation
+    world_size = 3
+    sim = simp.make_simulator(world_size=world_size)
+    mp.set_root_context(sim)
+
+    # Define computation
+    def jax_add(x, y):
+        return x + y
+
+    # Define the SPU execution function
+    def exec_spu(x, y):
+        # Create SPU config and parties
+        spu_config = spu.SPUConfig()
+        spu_parties = (0, 1, 2)
+
+        # Manual encryption using make_shares
+        x_shares = simp.pcall_static((0,), spu.make_shares, spu_config, x, count=3)
+        x_enc = simp.converge(*[
+            simp.shuffle_static(x_shares[i], {spu_parties[i]: 0}) for i in range(3)
+        ])
+
+        y_shares = simp.pcall_static((0,), spu.make_shares, spu_config, y, count=3)
+        y_enc = simp.converge(*[
+            simp.shuffle_static(y_shares[i], {spu_parties[i]: 0}) for i in range(3)
+        ])
+
+        # Execute on SPU
+        z_enc = simp.pcall_static(
+            spu_parties, spu.run_jax, spu_config, jax_add, x_enc, y_enc
+        )
+
+        # Decrypt (SPU -> Public)
+        z_shares = [
+            simp.shuffle_static(
+                simp.pcall_static((source,), lambda x: x, z_enc), {0: source}
+            )
+            for source in spu_parties
+        ]
+        z_mp = simp.pcall_static(
+            (0,), lambda *s: spu.reconstruct(spu_config, s), *z_shares
+        )
+
+        return z_mp
+
+    # Compile with dynamic shape tensor
+    tracer = el.Tracer()
+    tensor_type = elt.TensorType(elt.f32, (-1,))
+    x_obj = tracer._new_arg(tensor_type)
+    y_obj = tracer._new_arg(tensor_type)
+    traced_fn = mp.compile(exec_spu, x_obj, y_obj)
+    out_type = traced_fn.graph.outputs[0].type
+    assert isinstance(out_type, elt.MPType)
+    out_type = out_type.value_type
+
+    # print(f"Graph structure:\n{traced_fn.graph.to_string(verbose=True)}")
+    assert isinstance(out_type, elt.TensorType) and out_type.shape == (-1,)
+    # Verify the graph contains dynamic shape notation
+    assert "Tensor[f32, (-1)" in traced_fn.graph.to_string(verbose=True)
+
+    # Phase 2: Execution with various test inputs
+    test_cases = [
+        np.array([1.0, 2.0, 3.0], dtype=np.float32),  # Size 3
+        np.array([0.5, -1.5, 2.0, 3.5], dtype=np.float32),  # Size 4
+        np.arange(5, dtype=np.float32),  # Size 5
+    ]
+
+    for input_data in test_cases:
+        # Need to run within simp context since this uses simp operations
+        with sim:
+            # Create MP objects from the input data
+            x_mp = simp.constant((0,), input_data)
+            y_mp = simp.constant((0,), input_data)
+
+            # Execute the compiled function with MP objects
+            result = mp.evaluate(traced_fn, x_mp, y_mp)
+
+        # Verify the result - need to fetch from DriverVar
+        expected = input_data + input_data
+        result_values = mp.fetch(result)
+        np.testing.assert_allclose(result_values[0], expected)

--- a/tests/backends/test_tensor_impl.py
+++ b/tests/backends/test_tensor_impl.py
@@ -75,18 +75,20 @@ def test_tensor_run_dynamic_shape():
     # jax.config.update("jax_enable_x64", True)
 
     # Phase 1: Define function with type annotations
-    @tensor.mark_symbolic_shapes(in_shapes=[("rows",)])
     def square(x: jnp.ndarray):
         return jnp.square(x)
 
     def exec(x):
-        return tensor.run_jax(square, x)
+        return tensor.run_jax(square, x, symbolic_shapes=[("rows",)])
 
     tracer = el.Tracer()
     tensor_type = elt.TensorType(elt.f32, (-1,))
     x_obj = tracer._new_arg(tensor_type)
     traced_fn = mp.compile(exec, x_obj)
+    out_type = traced_fn.graph.outputs[0].type
 
+    # print(f"Graph structure:\n{traced_fn.graph.to_string(verbose=True)}")
+    assert isinstance(out_type, elt.TensorType) and out_type.shape == (-1,)
     assert "tensor<?xf32>" in traced_fn.graph.to_string(verbose=True)
 
     # Phase 2: Execute with various test inputs to verify run_jax_impl handles dynamic shapes

--- a/tests/dialects/test_tensor.py
+++ b/tests/dialects/test_tensor.py
@@ -41,7 +41,6 @@ def test_tensor_run_jax_op_emitted():
 
 
 def test_tensor_run_jax_on_dynamic_shape():
-    from mplang.dialects.tensor import mark_symbolic_shapes
 
     tracer = el.get_current_context()
     value = el.Value("xx", elt.TensorType(elt.f32, (-1,)))
@@ -54,12 +53,11 @@ def test_tensor_run_jax_on_dynamic_shape():
     op = traced.graph.operations[0]
     assert "tensor<?xf32>" in op.attrs["stablehlo_code"]
 
-    @mark_symbolic_shapes(in_shapes=[("x", "y"), ("x", "y")])
     def _add_dim2(x, y):
         return x + y
 
     def wrapper1(x, y):
-        return run_jax(_add_dim2, x, y)
+        return run_jax(_add_dim2, x, y, symbolic_shapes=[("x", "y"), ("x", "y")])
 
     tensor_type = elt.TensorType(elt.f32, (-1, -1))
     x = el.TraceObject(el.Value("x", tensor_type), tracer)  # type: ignore


### PR DESCRIPTION
When SPU's `run_jax` compiled functions with dynamic (symbolic) input shapes, it substituted `-1` dims with `1` for JAX lowering but then used those concrete shapes as the output types — causing downstream code to see static `1` where it should see `-1`.

## Changes

- **`mplang/dialects/_jax_utils.py`** (new): Extracted shared JAX compilation logic (`compile_jax`, `JaxCompilation`, `_make_placeholders`) from `tensor.py` into a shared module so both `tensor` and `spu` dialects can use it.

- **`mplang/dialects/spu.py`**:
  - Added `symbolic_shapes` parameter to `run_jax` (mirrors `tensor.run_jax`).
  - When inputs have dynamic dims, delegates to `compile_jax` (from `_jax_utils`) to get output types with symbolic dims correctly mapped to `-1` instead of using the JAX-lowered concrete shapes.
  - Consolidated `output_shapes`/`output_dtypes` parameters into a single `output_types: list[elt.TensorType]` in `_exec_ae`.

- **`mplang/dialects/tensor.py`**: Removed duplicated `RunJaxCompilation`, `_out_info_to_edsl`, `mark_symbolic_shapes`, and related helpers — now imported from `_jax_utils`. Renamed `get_run_jax_compilation` → `get_jax_compilation`.

- **`tests/backends/test_spu_impl.py`**: Added tests for dynamic-shape SPU execution.