### PR TITLE
feat: add async execution endpoints (/exec/async, /exec/{id}/status)

### DIFF
--- a/mplang/backends/simp_worker/http.py
+++ b/mplang/backends/simp_worker/http.py
@@ -643,26 +643,26 @@ def register_routes(
             raise HTTPException(status_code=500, detail=str(e)) from e
 
     @app.post("/exec/async")
-    async def execute_async(req: ExecRequest) -> dict[str, str | None]:
+    async def execute_async(req: ExecRequest) -> dict[str, str]:
         """Submit async graph execution, return immediately with exec_id."""
         exec_id = req.job_id
         if not exec_id:
-            return {"exec_id": "-1", "error": "job_id is required for async execution"}
+            raise HTTPException(status_code=400, detail="job_id is required for async execution")
         logger.debug(f"Worker {rank} received async exec request, exec_id={exec_id}")
         try:
             graph = serde.loads_b64(req.graph)
             inputs = serde.loads_b64(req.inputs)
         except Exception as e:
             logger.error(f"Worker {rank} async exec deserialization failed: {e}")
-            return {"exec_id": "-1", "error": str(e)}
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
         for existing_task in async_tasks.values():
             if existing_task.status in (AsyncTaskStatus.PENDING, AsyncTaskStatus.RUNNING):
-                return {"exec_id": "-1", "error": "another task is already running"}
+                raise HTTPException(status_code=409, detail="another task is already running")
 
         async_tasks[exec_id] = AsyncTaskState(status=AsyncTaskStatus.PENDING)
         exec_pool.submit(_do_execute_async, exec_id, graph, inputs, req.job_id)
-        return {"exec_id": exec_id, "error": None}
+        return {"exec_id": exec_id}
 
     @app.get("/exec/{exec_id}/status")
     async def get_exec_status(exec_id: str) -> dict[str, str | None]:

--- a/mplang/backends/simp_worker/http.py
+++ b/mplang/backends/simp_worker/http.py
@@ -610,6 +610,20 @@ def register_routes(
             return None
         return [store.put(res) if res is not None else None for res in result]
 
+    _async_tasks: dict[str, AsyncTaskState] = {}
+
+    def _do_execute_async(exec_id: str, graph: Graph, inputs: list[Any], job_id: str | None = None) -> None:
+        """Wrapper that updates AsyncTaskState around _do_execute."""
+        _async_tasks[exec_id].status = AsyncTaskStatus.RUNNING
+        try:
+            result = _do_execute(graph, inputs, job_id)
+            _async_tasks[exec_id].status = AsyncTaskStatus.SUCCESS
+            _async_tasks[exec_id].result = serde.dumps_b64(result)
+        except Exception as e:
+            logger.error(f"Worker {rank} async exec failed: {e}")
+            _async_tasks[exec_id].status = AsyncTaskStatus.FAILED
+            _async_tasks[exec_id].error = str(e)
+
     @app.post("/exec")
     async def execute(req: ExecRequest) -> dict[str, str]:
         """Execute a graph on this worker."""
@@ -626,6 +640,22 @@ def register_routes(
         except Exception as e:
             logger.error(f"Worker {rank} exec failed: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
+
+    @app.post("/exec/async")
+    async def execute_async(req: ExecRequest) -> dict[str, str | None]:
+        """Submit async graph execution, return immediately with exec_id."""
+        exec_id = req.job_id or ""
+        logger.debug(f"Worker {rank} received async exec request, exec_id={exec_id}")
+        try:
+            graph = serde.loads_b64(req.graph)
+            inputs = serde.loads_b64(req.inputs)
+        except Exception as e:
+            logger.error(f"Worker {rank} async exec deserialization failed: {e}")
+            return {"exec_id": "-1", "error": str(e)}
+
+        _async_tasks[exec_id] = AsyncTaskState(status=AsyncTaskStatus.PENDING)
+        exec_pool.submit(_do_execute_async, exec_id, graph, inputs, req.job_id)
+        return {"exec_id": exec_id, "error": None}
 
     @app.put("/comm/{key}")
     async def receive_comm(key: str, req: CommRequest) -> dict[str, str]:

--- a/mplang/backends/simp_worker/http.py
+++ b/mplang/backends/simp_worker/http.py
@@ -610,6 +610,7 @@ def register_routes(
             return None
         return [store.put(res) if res is not None else None for res in result]
 
+    # Mutable closure state shared between endpoint handlers and exec_pool threads.
     _async_tasks: dict[str, AsyncTaskState] = {}
 
     def _do_execute_async(exec_id: str, graph: Graph, inputs: list[Any], job_id: str | None = None) -> None:
@@ -644,7 +645,9 @@ def register_routes(
     @app.post("/exec/async")
     async def execute_async(req: ExecRequest) -> dict[str, str | None]:
         """Submit async graph execution, return immediately with exec_id."""
-        exec_id = req.job_id or ""
+        exec_id = req.job_id
+        if not exec_id:
+            return {"exec_id": "-1", "error": "job_id is required for async execution"}
         logger.debug(f"Worker {rank} received async exec request, exec_id={exec_id}")
         try:
             graph = serde.loads_b64(req.graph)
@@ -652,6 +655,10 @@ def register_routes(
         except Exception as e:
             logger.error(f"Worker {rank} async exec deserialization failed: {e}")
             return {"exec_id": "-1", "error": str(e)}
+
+        for existing_task in _async_tasks.values():
+            if existing_task.status in (AsyncTaskStatus.PENDING, AsyncTaskStatus.RUNNING):
+                return {"exec_id": "-1", "error": "another task is already running"}
 
         _async_tasks[exec_id] = AsyncTaskState(status=AsyncTaskStatus.PENDING)
         exec_pool.submit(_do_execute_async, exec_id, graph, inputs, req.job_id)

--- a/mplang/backends/simp_worker/http.py
+++ b/mplang/backends/simp_worker/http.py
@@ -41,6 +41,7 @@ import pathlib
 import threading
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 import httpx
@@ -98,6 +99,8 @@ class SendTimeoutError(TimeoutError):
 # ---------------------------------------------------------------------------
 
 __all__ = [
+    "AsyncTaskState",
+    "AsyncTaskStatus",
     "CommConfig",
     "CommStats",
     "HttpCommunicator",
@@ -538,6 +541,24 @@ class FetchRequest(BaseModel):
     """Request model for /fetch endpoint."""
 
     uri: str
+
+
+class AsyncTaskStatus(str, Enum):
+    """Status of an async execution task."""
+
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
+@dataclass
+class AsyncTaskState:
+    """Tracks the state of an async execution task."""
+
+    status: AsyncTaskStatus
+    result: str | None = None
+    error: str | None = None
 
 
 def register_routes(

--- a/mplang/backends/simp_worker/http.py
+++ b/mplang/backends/simp_worker/http.py
@@ -657,6 +657,23 @@ def register_routes(
         exec_pool.submit(_do_execute_async, exec_id, graph, inputs, req.job_id)
         return {"exec_id": exec_id, "error": None}
 
+    @app.get("/exec/{exec_id}/status")
+    async def get_exec_status(exec_id: str) -> dict[str, str | None]:
+        """Poll the status of an async execution task."""
+        task = _async_tasks.get(exec_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"exec_id '{exec_id}' not found")
+
+        response: dict[str, str | None] = {
+            "exec_id": exec_id,
+            "status": task.status.value,
+        }
+        if task.status == AsyncTaskStatus.SUCCESS:
+            response["result"] = task.result
+        elif task.status == AsyncTaskStatus.FAILED:
+            response["error"] = task.error
+        return response
+
     @app.put("/comm/{key}")
     async def receive_comm(key: str, req: CommRequest) -> dict[str, str]:
         """Receive communication data from another worker."""

--- a/mplang/backends/simp_worker/http.py
+++ b/mplang/backends/simp_worker/http.py
@@ -41,7 +41,7 @@ import pathlib
 import threading
 import time
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 import httpx
@@ -543,7 +543,7 @@ class FetchRequest(BaseModel):
     uri: str
 
 
-class AsyncTaskStatus(str, Enum):
+class AsyncTaskStatus(StrEnum):
     """Status of an async execution task."""
 
     PENDING = "PENDING"
@@ -611,19 +611,19 @@ def register_routes(
         return [store.put(res) if res is not None else None for res in result]
 
     # Mutable closure state shared between endpoint handlers and exec_pool threads.
-    _async_tasks: dict[str, AsyncTaskState] = {}
+    async_tasks: dict[str, AsyncTaskState] = {}
 
     def _do_execute_async(exec_id: str, graph: Graph, inputs: list[Any], job_id: str | None = None) -> None:
         """Wrapper that updates AsyncTaskState around _do_execute."""
-        _async_tasks[exec_id].status = AsyncTaskStatus.RUNNING
+        async_tasks[exec_id].status = AsyncTaskStatus.RUNNING
         try:
             result = _do_execute(graph, inputs, job_id)
-            _async_tasks[exec_id].status = AsyncTaskStatus.SUCCESS
-            _async_tasks[exec_id].result = serde.dumps_b64(result)
+            async_tasks[exec_id].status = AsyncTaskStatus.SUCCESS
+            async_tasks[exec_id].result = serde.dumps_b64(result)
         except Exception as e:
             logger.error(f"Worker {rank} async exec failed: {e}")
-            _async_tasks[exec_id].status = AsyncTaskStatus.FAILED
-            _async_tasks[exec_id].error = str(e)
+            async_tasks[exec_id].status = AsyncTaskStatus.FAILED
+            async_tasks[exec_id].error = str(e)
 
     @app.post("/exec")
     async def execute(req: ExecRequest) -> dict[str, str]:
@@ -656,18 +656,18 @@ def register_routes(
             logger.error(f"Worker {rank} async exec deserialization failed: {e}")
             return {"exec_id": "-1", "error": str(e)}
 
-        for existing_task in _async_tasks.values():
+        for existing_task in async_tasks.values():
             if existing_task.status in (AsyncTaskStatus.PENDING, AsyncTaskStatus.RUNNING):
                 return {"exec_id": "-1", "error": "another task is already running"}
 
-        _async_tasks[exec_id] = AsyncTaskState(status=AsyncTaskStatus.PENDING)
+        async_tasks[exec_id] = AsyncTaskState(status=AsyncTaskStatus.PENDING)
         exec_pool.submit(_do_execute_async, exec_id, graph, inputs, req.job_id)
         return {"exec_id": exec_id, "error": None}
 
     @app.get("/exec/{exec_id}/status")
     async def get_exec_status(exec_id: str) -> dict[str, str | None]:
         """Poll the status of an async execution task."""
-        task = _async_tasks.get(exec_id)
+        task = async_tasks.get(exec_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"exec_id '{exec_id}' not found")
 

--- a/tests/backends/simp_worker/test_async_exec.py
+++ b/tests/backends/simp_worker/test_async_exec.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Ant Group Co., Ltd.
+# Copyright 2026 Ant Group Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/backends/simp_worker/test_async_exec.py
+++ b/tests/backends/simp_worker/test_async_exec.py
@@ -22,7 +22,7 @@ from fastapi.testclient import TestClient
 
 import mplang.edsl as el
 from mplang.backends.simp_worker.http import create_worker_app
-from mplang.dialects import simp, tensor
+from mplang.dialects import simp
 from mplang.edsl import serde
 
 
@@ -61,9 +61,8 @@ class TestExecAsync:
         assert resp.status_code == 200
         data = resp.json()
         assert data["exec_id"] == "test-job-1"
-        assert data["error"] is None
 
-    def test_submit_bad_graph_returns_error(self, single_worker_client):
+    def test_submit_bad_graph_returns_400(self, single_worker_client):
         client = single_worker_client
         payload = {
             "graph": "not-valid-base64-graph",
@@ -72,12 +71,9 @@ class TestExecAsync:
         }
 
         resp = client.post("/exec/async", json=payload)
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["exec_id"] == "-1"
-        assert data["error"] is not None
+        assert resp.status_code == 400
 
-    def test_submit_missing_job_id_returns_error(self, single_worker_client):
+    def test_submit_missing_job_id_returns_400(self, single_worker_client):
         client = single_worker_client
         graph = _make_constant_graph()
         payload = {
@@ -86,10 +82,8 @@ class TestExecAsync:
         }
 
         resp = client.post("/exec/async", json=payload)
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["exec_id"] == "-1"
-        assert "job_id is required" in data["error"]
+        assert resp.status_code == 400
+        assert "job_id is required" in resp.json()["detail"]
 
 
 class TestExecStatus:

--- a/tests/backends/simp_worker/test_async_exec.py
+++ b/tests/backends/simp_worker/test_async_exec.py
@@ -1,0 +1,130 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for async exec endpoints (/exec/async and /exec/{exec_id}/status)."""
+
+import time
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import mplang.edsl as el
+from mplang.backends.simp_worker.http import create_worker_app
+from mplang.dialects import simp, tensor
+from mplang.edsl import serde
+
+
+@pytest.fixture
+def single_worker_client():
+    """Create a TestClient with a single-worker app (rank=0, world_size=1)."""
+    endpoints = ["http://127.0.0.1:19999"]
+    app = create_worker_app(rank=0, world_size=1, endpoints=endpoints)
+    with TestClient(app) as client:
+        yield client
+
+
+def _make_constant_graph():
+    """Build a simple graph: constant → output."""
+
+    def workflow():
+        return simp.constant((0,), np.array([1.0, 2.0]))
+
+    traced = el.trace(workflow)
+    return traced.graph
+
+
+class TestExecAsync:
+    """Tests for POST /exec/async."""
+
+    def test_submit_returns_exec_id(self, single_worker_client):
+        client = single_worker_client
+        graph = _make_constant_graph()
+        payload = {
+            "graph": serde.dumps_b64(graph),
+            "inputs": serde.dumps_b64([]),
+            "job_id": "test-job-1",
+        }
+
+        resp = client.post("/exec/async", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["exec_id"] == "test-job-1"
+        assert data["error"] is None
+
+    def test_submit_bad_graph_returns_error(self, single_worker_client):
+        client = single_worker_client
+        payload = {
+            "graph": "not-valid-base64-graph",
+            "inputs": serde.dumps_b64([]),
+            "job_id": "test-bad",
+        }
+
+        resp = client.post("/exec/async", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["exec_id"] == "-1"
+        assert data["error"] is not None
+
+    def test_submit_missing_job_id_returns_error(self, single_worker_client):
+        client = single_worker_client
+        graph = _make_constant_graph()
+        payload = {
+            "graph": serde.dumps_b64(graph),
+            "inputs": serde.dumps_b64([]),
+        }
+
+        resp = client.post("/exec/async", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["exec_id"] == "-1"
+        assert "job_id is required" in data["error"]
+
+
+class TestExecStatus:
+    """Tests for GET /exec/{exec_id}/status."""
+
+    def test_poll_until_success(self, single_worker_client):
+        client = single_worker_client
+        graph = _make_constant_graph()
+        payload = {
+            "graph": serde.dumps_b64(graph),
+            "inputs": serde.dumps_b64([]),
+            "job_id": "test-poll-1",
+        }
+
+        # Submit
+        resp = client.post("/exec/async", json=payload)
+        assert resp.json()["exec_id"] == "test-poll-1"
+
+        # Poll until terminal state (with timeout)
+        deadline = time.monotonic() + 30
+        status = None
+        while time.monotonic() < deadline:
+            resp = client.get("/exec/test-poll-1/status")
+            assert resp.status_code == 200
+            data = resp.json()
+            status = data["status"]
+            if status in ("SUCCESS", "FAILED"):
+                break
+            time.sleep(0.1)
+
+        assert status == "SUCCESS"
+        assert data["result"] is not None
+
+    def test_poll_nonexistent_returns_404(self, single_worker_client):
+        client = single_worker_client
+
+        resp = client.get("/exec/nonexistent-id/status")
+        assert resp.status_code == 404


### PR DESCRIPTION
- Add POST /exec/async endpoint that submits graph execution and returns immediately
  with exec_id, instead of blocking until completion like /exec
- Add GET /exec/{exec_id}/status endpoint for polling execution state
(PENDING/RUNNING/SUCCESS/FAILED)
- Enforce one-task-at-a-time: rejects new async submissions while another task is
PENDING or RUNNING
- Require job_id for async execution (used as exec_id)
- No changes to existing sync /exec endpoint